### PR TITLE
Feat/login state 67

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-router-dom": "^7.6.3",
     "tailwindcss": "^4.1.11",
     "three": "^0.178.0",
-    "three-stdlib": "^2.36.0"
+    "three-stdlib": "^2.36.0",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       three-stdlib:
         specifier: ^2.36.0
         version: 2.36.0(three@0.178.0)
+      zustand:
+        specifier: ^5.0.6
+        version: 5.0.6(@types/react@19.1.8)(react@19.1.0)
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
@@ -1694,6 +1697,24 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zustand@5.0.6:
+    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -3117,3 +3138,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.6(@types/react@19.1.8)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.8
+      react: 19.1.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,10 @@
-import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom';
+import {
+  BrowserRouter,
+  Navigate,
+  Outlet,
+  Route,
+  Routes,
+} from 'react-router-dom';
 import LandingPage from './domains/Landing/pages/LandingPage';
 import MapPage from './domains/Map/pages/MapPage';
 import Header from './components/Header';
@@ -17,6 +23,8 @@ import StatisticsPage from './domains/MyPage/pages/StatisticsPage';
 import FavoritesPage from './domains/MyPage/pages/FavoritesPage';
 import EditProfilePage from '@/domains/MyPage/pages/EditProfilePage';
 import MySharingPage from '@/domains/MyPage/pages/MySharingPage';
+import { useAuthStore } from '@/store/useAuthStore';
+import dolphinFind from '@/assets/image/dolphin_find.png';
 
 const AppLayout = () => {
   return (
@@ -38,35 +46,92 @@ const SidebarLayout = () => {
   );
 };
 
+const NotFoundPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen m-6 text-center break-keep">
+      <img
+        src={dolphinFind}
+        alt="무언가를 찾는 돌고래 캐릭터"
+        className="w-40 mb-5"
+      />
+      <h1 className="text-xl md:text-2xl font-bold mb-4">
+        404 - 페이지를 찾을 수 없습니다.
+      </h1>
+      <p>요청하신 페이지가 존재하지 않거나 잘못된 경로입니다.</p>
+      <a href="/" className="mt-6 text-blue-600 underline">
+        홈으로 돌아가기
+      </a>
+    </div>
+  );
+};
+
+const ProtectedRoute = () => {
+  const { isLoggedIn } = useAuthStore();
+
+  if (!isLoggedIn) {
+    // 로그인 안 된 경우 로그인 페이지로 이동
+    return <Navigate to="/" replace />;
+  }
+
+  // 로그인 됐으면 자식 라우트 렌더링
+  return <Outlet />;
+};
+
+export const PublicRoute = () => {
+  const { isLoggedIn } = useAuthStore();
+
+  if (isLoggedIn) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};
+
 function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {/* 헤더 공통 적용 */}
         <Route element={<AppLayout />}>
+          {/* 로그인 안 된 사람도 접근 가능한 기본 페이지들 */}
           <Route path="/" element={<LandingPage />} />
           <Route path="/map" element={<MapPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignUpPage />} />
 
-          {/* 사이드바 레이아웃 포함 */}
+          {/* 로그인 되어 있으면 못 가도록 설정 (로그인/회원가입) */}
+          <Route element={<PublicRoute />}>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignUpPage />} />
+          </Route>
+
+          {/* 인증 필요 없는 explore 메뉴 */}
           <Route element={<SidebarLayout />}>
             <Route path="/explore/rankings" element={<RankingPage />} />
             <Route path="/explore/share" element={<SharePage />} />
-            <Route path="/explore/share/write" element={<ShareWritePage />} />
             <Route
               path="/explore/share/:postId"
               element={<ShareDetailPage />}
             />
             <Route path="/explore/membership" element={<MembershipPage />} />
-            <Route path="/mypage/profile" element={<ProfilePage />} />
-            <Route path="/mypage/edit" element={<EditProfilePage />} />
-            <Route path="/mypage/collection" element={<CollectionPage />} />
-            <Route path="/mypage/missions" element={<MissionPage />} />
-            <Route path="/mypage/statistics" element={<StatisticsPage />} />
-            <Route path="/mypage/favorites" element={<FavoritesPage />} />
-            <Route path="/mypage/sharing" element={<MySharingPage />} />
           </Route>
+
+          {/* 로그인 필요 */}
+          <Route element={<ProtectedRoute />}>
+            <Route path="/explore/share/write" element={<ShareWritePage />} />
+          </Route>
+
+          {/* 로그인 필요 */}
+          <Route element={<ProtectedRoute />}>
+            <Route element={<SidebarLayout />}>
+              <Route path="/mypage/profile" element={<ProfilePage />} />
+              <Route path="/mypage/edit" element={<EditProfilePage />} />
+              <Route path="/mypage/collection" element={<CollectionPage />} />
+              <Route path="/mypage/missions" element={<MissionPage />} />
+              <Route path="/mypage/statistics" element={<StatisticsPage />} />
+              <Route path="/mypage/favorites" element={<FavoritesPage />} />
+              <Route path="/mypage/sharing" element={<MySharingPage />} />
+            </Route>
+          </Route>
+
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/domains/Auth/components/LoginForm.tsx
+++ b/src/domains/Auth/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { validateEmail } from '../utils/validation';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/Button';
 import { useLogin } from '../hooks/useLogin';
+import { useAuthStore } from '@/store/useAuthStore';
 
 const LoginForm = ({ onSignUpClick }: { onSignUpClick?: () => void }) => {
   const navigate = useNavigate();
@@ -94,6 +95,9 @@ const LoginForm = ({ onSignUpClick }: { onSignUpClick?: () => void }) => {
       });
 
       console.log('로그인 성공:', result);
+      // 로그인 성공 시 Zustand 상태 변경
+      useAuthStore.getState().setIsLoggedIn(true);
+
       navigate('/');
     } catch (error) {
       console.error('로그인 실패:', error);

--- a/src/domains/MyPage/api/favorites.ts
+++ b/src/domains/MyPage/api/favorites.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const baseURL = import.meta.env.VITE_API_URL;
-const token = import.meta.env.VITE_AUTH_TOKEN;
 
 export const getFavorites = async () => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.get(`${baseURL}/map/bookmark`, {
     headers: {
       Authorization: token,

--- a/src/domains/MyPage/api/mission.ts
+++ b/src/domains/MyPage/api/mission.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 const baseURL = import.meta.env.VITE_API_URL;
-const token = import.meta.env.VITE_AUTH_TOKEN;
 
 export const getUserAttendance = async (year: number, month: number) => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.get(`${baseURL}/user/attendance`, {
     params: {
       year,
@@ -18,6 +18,7 @@ export const getUserAttendance = async (year: number, month: number) => {
 };
 
 export const checkInAttendance = async () => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.post(
     `${baseURL}/user/attendance`,
     {},

--- a/src/domains/MyPage/api/profile.ts
+++ b/src/domains/MyPage/api/profile.ts
@@ -5,9 +5,9 @@ import type {
 import axios from 'axios';
 
 const baseURL = import.meta.env.VITE_API_URL;
-const token = import.meta.env.VITE_AUTH_TOKEN;
 
 export const getUserInfo = async (): Promise<UserInfoResponse> => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.post<UserInfoResponse>(
     `${baseURL}/user/currentUserInfo`,
     {},
@@ -25,6 +25,7 @@ export const editUserInfo = async (
   address: string,
   password: string,
 ) => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.put(
     `${baseURL}/user`,
     { nickname, address, password },
@@ -39,6 +40,7 @@ export const editUserInfo = async (
 };
 
 export const getUserStat = async (): Promise<UserStatResponse> => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.get<UserStatResponse>(`${baseURL}/user/stat`, {
     headers: {
       Authorization: token,
@@ -49,6 +51,7 @@ export const getUserStat = async (): Promise<UserStatResponse> => {
 };
 
 export const getUsageHistory = async () => {
+  const token = localStorage.getItem('authToken');
   const response = await axios.get(`${baseURL}/map/usage`, {
     headers: {
       Authorization: token,

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface AuthStore {
+  isLoggedIn: boolean;
+  setIsLoggedIn: (value: boolean) => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  isLoggedIn: !!localStorage.getItem('authToken'),
+  setIsLoggedIn: (value) => set({ isLoggedIn: value }),
+  logout: () => {
+    localStorage.removeItem('authToken');
+    set({ isLoggedIn: false });
+  },
+}));


### PR DESCRIPTION
## 🔗 관련 이슈

> 이 변경사항과 관련된 이슈 번호를 명시합니다.  
> 예: #123, #456

- #67 

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 전역 상태관리를 위한 zustand 설치
2. 로그인 상태에 따라 헤더 렌더링 및 라우팅 제한

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 로그인 상태에 따라서 헤더의 마이페이지와 로그인 <-> 로그아웃 변경하기 위해 zustand로 전역 상태 관리
- 라우팅 시 로그인 상태에 따라 접근 불가능 하도록 구현
- 404 페이지 구현

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- x

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
