### PR TITLE
Feat/rank api 120

### DIFF
--- a/src/domains/Explore/api/rank.ts
+++ b/src/domains/Explore/api/rank.ts
@@ -1,17 +1,20 @@
 import axios from 'axios';
-import type { UserRank } from '@/domains/Explore/components/ranking/UserTotalRanking';
+import type { UserRank } from '@/domains/Explore/types/rank';
+import type { StoreRank } from '@/domains/Explore/types/rank';
 
 const baseURL = import.meta.env.VITE_API_URL;
 
 export const getUserRank = async (): Promise<UserRank[]> => {
-  const token = localStorage.getItem('authToken');
   const response = await axios.get<{ data: UserRank[] }>(
     `${baseURL}/map/user/rank`,
-    {
-      headers: {
-        Authorization: token,
-      },
-    },
+  );
+
+  return response.data.data;
+};
+
+export const getStoreRank = async (): Promise<StoreRank[]> => {
+  const response = await axios.get<{ data: StoreRank[] }>(
+    `${baseURL}/map/store/rank`,
   );
 
   return response.data.data;

--- a/src/domains/Explore/api/rank.ts
+++ b/src/domains/Explore/api/rank.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import type { UserRank } from '@/domains/Explore/components/ranking/UserTotalRanking';
+
+const baseURL = import.meta.env.VITE_API_URL;
+
+export const getUserRank = async (): Promise<UserRank[]> => {
+  const token = localStorage.getItem('authToken');
+  const response = await axios.get<{ data: UserRank[] }>(
+    `${baseURL}/map/user/rank`,
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+
+  return response.data.data;
+};

--- a/src/domains/Explore/components/ranking/RankingList.tsx
+++ b/src/domains/Explore/components/ranking/RankingList.tsx
@@ -2,26 +2,28 @@ import type { UserRank } from '@/domains/Explore/components/ranking/UserTotalRan
 import medalGold from '@/assets/icons/medal_gold.png';
 import medalSilver from '@/assets/icons/medal_silver.png';
 import medalBronze from '@/assets/icons/medal_bronze.png';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { getUserInfo } from '@/domains/MyPage/api/profile';
 
 type RankingListProps = {
   rankList: UserRank[];
 };
 
-const cellBase = 'flex items-center justify-center';
+const cellBaseClass = 'flex items-center justify-center';
 const columnClass = {
-  rank: `w-[15%] ${cellBase} text-center font-bold`,
+  rank: `w-[15%] ${cellBaseClass} text-center font-bold`,
   nickname: 'w-[30%] flex flex-wrap gap-x-4 gap-y-1 items-center',
-  completion: `w-[20%] ${cellBase} text-center`,
-  level: `w-[15%] ${cellBase}`,
-  count: `w-[20%] ${cellBase} text-center`,
+  completion: `w-[20%] ${cellBaseClass} text-center`,
+  level: `w-[15%] ${cellBaseClass}`,
+  count: `w-[20%] ${cellBaseClass} text-center`,
 };
 
 const medals = [medalGold, medalSilver, medalBronze];
 
 const RankingList = ({ rankList }: RankingListProps) => {
   const [myNickname, setMyNickname] = useState<string | null>(null);
+  const [isPassedMyRank, setIsPassedMyRank] = useState(true);
+  const myRankRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
     const token = localStorage.getItem('authToken');
@@ -43,6 +45,28 @@ const RankingList = ({ rankList }: RankingListProps) => {
     fetchUser();
   }, []);
 
+  useEffect(() => {
+    if (!myRankRef.current) {
+      return;
+    }
+
+    const handleScroll = () => {
+      if (!myRankRef.current) return;
+
+      const rect = myRankRef.current.getBoundingClientRect();
+      setIsPassedMyRank(rect.bottom < 100);
+    };
+    window.addEventListener('scroll', handleScroll);
+    // 초기 상태 체크
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [myNickname]);
+
+  const myRank = rankList.find((user) => user.nickname === myNickname);
+
   return (
     <>
       <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-500 font-bold break-keep whitespace-normal">
@@ -53,12 +77,46 @@ const RankingList = ({ rankList }: RankingListProps) => {
         <div className={columnClass.count}>혜택 받은 횟수</div>
       </div>
 
-      <ul className="divide-y-2 divide-dashed divide-[#C3B69C]">
+      {myRank && isPassedMyRank && (
+        <div
+          className="sticky top-14 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10" // Add z-10 to ensure it's above other items
+        >
+          <div className={columnClass.rank}>
+            {rankList.indexOf(myRank) < 3 ? (
+              <img
+                src={medals[rankList.indexOf(myRank)]}
+                alt="메달"
+                className="mx-auto"
+              />
+            ) : (
+              <span className="text-xl">{rankList.indexOf(myRank) + 1}</span>
+            )}
+          </div>
+          <div className={columnClass.nickname}>
+            <span className="font-bold truncate overflow-hidden whitespace-nowrap">
+              {myRank.nickname}
+            </span>
+            {myRank.title && (
+              <span className="bg-red-300 px-2 py-1 rounded-2xl text-center w-fit whitespace-nowrap">
+                {myRank.title}
+              </span>
+            )}
+          </div>
+          <div className={columnClass.completion}>
+            {Number(myRank.completePercentage).toFixed(2).replace(/\.00$/, '')}%
+          </div>
+          <div className={columnClass.level}>Lv. {myRank.level}</div>
+          <div className={columnClass.count}>{myRank.storeUsage}회</div>
+        </div>
+      )}
+
+      <ul className="">
         {rankList.map((user, index) => (
           <li
             key={index}
+            ref={user.nickname === myNickname ? myRankRef : null}
             className={`flex sm:px-4 py-3.5 sm:py-4 justify-around items-center ${
-              user.nickname === myNickname
+              user.nickname === myNickname && !isPassedMyRank
                 ? 'sticky bottom-4 bg-[#BBE3E6] rounded-2xl'
                 : ''
             }`}

--- a/src/domains/Explore/components/ranking/RankingList.tsx
+++ b/src/domains/Explore/components/ranking/RankingList.tsx
@@ -1,7 +1,9 @@
-import type { UserRank } from './UserTotalRanking';
+import type { UserRank } from '@/domains/Explore/components/ranking/UserTotalRanking';
 import medalGold from '@/assets/icons/medal_gold.png';
 import medalSilver from '@/assets/icons/medal_silver.png';
 import medalBronze from '@/assets/icons/medal_bronze.png';
+import { useEffect, useState } from 'react';
+import { getUserInfo } from '@/domains/MyPage/api/profile';
 
 type RankingListProps = {
   rankList: UserRank[];
@@ -19,8 +21,27 @@ const columnClass = {
 const medals = [medalGold, medalSilver, medalBronze];
 
 const RankingList = ({ rankList }: RankingListProps) => {
-  // 임의 데이터
-  const username = 'neo348_20';
+  const [myNickname, setMyNickname] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem('authToken');
+    if (!token) {
+      setMyNickname(null);
+      return;
+    }
+
+    const fetchUser = async () => {
+      try {
+        const res = await getUserInfo();
+        setMyNickname(res.data.nickname);
+      } catch (err) {
+        console.error('사용자 정보 가져오기 실패', err);
+        setMyNickname(null);
+      }
+    };
+
+    fetchUser();
+  }, []);
 
   return (
     <>
@@ -37,7 +58,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
           <li
             key={index}
             className={`flex sm:px-4 py-3.5 sm:py-4 justify-around items-center ${
-              user.nickname === username
+              user.nickname === myNickname
                 ? 'sticky bottom-4 bg-[#BBE3E6] rounded-2xl'
                 : ''
             }`}
@@ -46,20 +67,29 @@ const RankingList = ({ rankList }: RankingListProps) => {
               {index < 3 ? (
                 <img src={medals[index]} alt="메달" className="mx-auto" />
               ) : (
-                <span className="text-xl">{user.rank}</span>
+                <span className="text-xl">{index + 1}</span>
               )}
             </div>
             <div className={columnClass.nickname}>
               <span className="font-bold truncate overflow-hidden whitespace-nowrap">
                 {user.nickname}
               </span>
-              <span className="bg-red-300 px-2 py-1 rounded-2xl text-center w-fit whitespace-nowrap">
-                {user.title}
-              </span>
+              {user.title && (
+                <span className="bg-red-300 px-2 py-1 rounded-2xl text-center w-fit whitespace-nowrap">
+                  {user.title}
+                </span>
+              )}
             </div>
-            <div className={columnClass.completion}>{user.completion}</div>
+            <div className={columnClass.completion}>
+              <div className={columnClass.completion}>
+                {Number(user.completePercentage)
+                  .toFixed(2)
+                  .replace(/\.00$/, '')}
+                %
+              </div>
+            </div>
             <div className={columnClass.level}>Lv. {user.level}</div>
-            <div className={columnClass.count}>{user.benefitCount}회</div>
+            <div className={columnClass.count}>{user.storeUsage}회</div>
           </li>
         ))}
       </ul>

--- a/src/domains/Explore/components/ranking/RankingList.tsx
+++ b/src/domains/Explore/components/ranking/RankingList.tsx
@@ -79,7 +79,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
 
       {myRank && isPassedMyRank && (
         <div
-          className="sticky top-14 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10" // Add z-10 to ensure it's above other items
+          className="sticky top-15 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10" // Add z-10 to ensure it's above other items
         >
           <div className={columnClass.rank}>
             {rankList.indexOf(myRank) < 3 ? (
@@ -97,7 +97,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
               {myRank.nickname}
             </span>
             {myRank.title && (
-              <span className="bg-red-300 px-2 py-1 rounded-2xl text-center w-fit whitespace-nowrap">
+              <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
                 {myRank.title}
               </span>
             )}
@@ -133,7 +133,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
                 {user.nickname}
               </span>
               {user.title && (
-                <span className="bg-red-300 px-2 py-1 rounded-2xl text-center w-fit whitespace-nowrap">
+                <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
                   {user.title}
                 </span>
               )}

--- a/src/domains/Explore/components/ranking/StoreRanking.tsx
+++ b/src/domains/Explore/components/ranking/StoreRanking.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { getStoreRank } from '@/domains/Explore/api/rank';
+import StoreRankingList from './StoreRankingList';
+import type { StoreRank } from '@/domains/Explore/types/rank';
+
+const UserStoreRanking = () => {
+  const [storeRankList, setStoreRankList] = useState<StoreRank[]>([]);
+
+  useEffect(() => {
+    const fetchStoreRank = async () => {
+      const storeRank = await getStoreRank();
+      setStoreRankList(storeRank);
+    };
+    fetchStoreRank();
+  }, []);
+
+  if (!storeRankList || storeRankList.length === 0) {
+    return (
+      <div className="text-center text-gray-400">
+        아직 랭킹 정보가 없습니다 💤
+      </div>
+    );
+  }
+  return <StoreRankingList rankList={storeRankList} />;
+};
+
+export default UserStoreRanking;

--- a/src/domains/Explore/components/ranking/StoreRankingList.tsx
+++ b/src/domains/Explore/components/ranking/StoreRankingList.tsx
@@ -1,0 +1,73 @@
+import type { StoreRank } from '@/domains/Explore/types/rank';
+import medalGold from '@/assets/icons/medal_gold.png';
+import medalSilver from '@/assets/icons/medal_silver.png';
+import medalBronze from '@/assets/icons/medal_bronze.png';
+
+type StoreRankingListProps = {
+  rankList: StoreRank[];
+};
+
+const cellBaseClass = 'flex items-center justify-center';
+const columnClass = {
+  rank: `w-[10%] ${cellBaseClass} text-center font-bold`,
+  store: 'w-[35%] flex flex-wrap gap-x-4 gap-y-1 items-center',
+  category: `w-[15%] ${cellBaseClass} text-center`,
+  address: `w-[30%] ${cellBaseClass} text-sm text-left`,
+  usage: `w-[10%] ${cellBaseClass} text-center`,
+};
+
+const medals = [medalGold, medalSilver, medalBronze];
+
+const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
+  return (
+    <>
+      <div className="mt-4 bg-[#E6F4F1] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-700 font-bold whitespace-normal">
+        <div className={columnClass.rank}>순위</div>
+        <div className={columnClass.store}>매장</div>
+        <div className={columnClass.category}>카테고리</div>
+        <div className={columnClass.address}>주소</div>
+        <div className={columnClass.usage}>이용횟수</div>
+      </div>
+
+      <ul>
+        {rankList.map((store, index) => (
+          <li
+            key={store.id}
+            className="flex sm:px-4 py-3.5 sm:py-4 justify-around items-center"
+          >
+            <div className={columnClass.rank}>
+              {index < 3 ? (
+                <img src={medals[index]} alt="메달" className="mx-auto" />
+              ) : (
+                <span className="text-xl">{index + 1}</span>
+              )}
+            </div>
+
+            <div className={columnClass.store}>
+              <img
+                src={store.brandImageUrl}
+                alt={store.brandName}
+                className="w-6 h-6 object-contain rounded"
+              />
+              <span className="font-bold truncate whitespace-nowrap">
+                {store.name}
+              </span>
+            </div>
+
+            <div className={columnClass.category}>
+              <span className="bg-[#d1f0e0] px-2 py-1 rounded-xl text-sm">
+                {store.category}
+              </span>
+            </div>
+
+            <div className={columnClass.address}>{store.address}</div>
+
+            <div className={columnClass.usage}>{store.usageCount}회</div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default StoreRankingList;

--- a/src/domains/Explore/components/ranking/UserRankingList.tsx
+++ b/src/domains/Explore/components/ranking/UserRankingList.tsx
@@ -1,4 +1,4 @@
-import type { UserRank } from '@/domains/Explore/components/ranking/UserTotalRanking';
+import type { UserRank } from '@/domains/Explore/types/rank';
 import medalGold from '@/assets/icons/medal_gold.png';
 import medalSilver from '@/assets/icons/medal_silver.png';
 import medalBronze from '@/assets/icons/medal_bronze.png';
@@ -20,7 +20,7 @@ const columnClass = {
 
 const medals = [medalGold, medalSilver, medalBronze];
 
-const RankingList = ({ rankList }: RankingListProps) => {
+const UserRankingList = ({ rankList }: RankingListProps) => {
   const [myNickname, setMyNickname] = useState<string | null>(null);
   const [isPassedMyRank, setIsPassedMyRank] = useState(true);
   const myRankRef = useRef<HTMLLIElement>(null);
@@ -69,7 +69,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
 
   return (
     <>
-      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-500 font-bold break-keep whitespace-normal">
+      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-700 font-bold break-keep whitespace-normal">
         <div className={columnClass.rank}>순위</div>
         <div className={columnClass.nickname}>닉네임</div>
         <div className={columnClass.completion}>도감 완성률</div>
@@ -78,9 +78,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
       </div>
 
       {myRank && isPassedMyRank && (
-        <div
-          className="sticky top-15 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10" // Add z-10 to ensure it's above other items
-        >
+        <div className="sticky top-15 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10">
           <div className={columnClass.rank}>
             {rankList.indexOf(myRank) < 3 ? (
               <img
@@ -110,7 +108,7 @@ const RankingList = ({ rankList }: RankingListProps) => {
         </div>
       )}
 
-      <ul className="">
+      <ul>
         {rankList.map((user, index) => (
           <li
             key={index}
@@ -155,4 +153,4 @@ const RankingList = ({ rankList }: RankingListProps) => {
   );
 };
 
-export default RankingList;
+export default UserRankingList;

--- a/src/domains/Explore/components/ranking/UserStoreRanking.tsx
+++ b/src/domains/Explore/components/ranking/UserStoreRanking.tsx
@@ -1,5 +1,0 @@
-const UserStoreRanking = () => {
-  return <div>UserStoreRanking</div>;
-};
-
-export default UserStoreRanking;

--- a/src/domains/Explore/components/ranking/UserTotalRanking.tsx
+++ b/src/domains/Explore/components/ranking/UserTotalRanking.tsx
@@ -1,16 +1,8 @@
 import { useEffect, useState } from 'react';
-import RankingList from '@/domains/Explore/components/ranking/RankingList';
+import UserRankingList from '@/domains/Explore/components/ranking/UserRankingList';
 import RankingPodium from '@/domains/Explore/components/ranking/RankingPodium';
 import { getUserRank } from '@/domains/Explore/api/rank';
-
-export type UserRank = {
-  rank: number;
-  nickname: string;
-  title: string;
-  completePercentage: string;
-  level: number;
-  storeUsage: number;
-};
+import type { UserRank } from '@/domains/Explore/types/rank';
 
 const UserTotalRanking = () => {
   const [rankList, setRankList] = useState<UserRank[]>([]);
@@ -39,7 +31,7 @@ const UserTotalRanking = () => {
   return (
     <>
       <RankingPodium podiumRanks={podiumRanks} />
-      <RankingList rankList={rankList} />
+      <UserRankingList rankList={rankList} />
     </>
   );
 };

--- a/src/domains/Explore/components/ranking/UserTotalRanking.tsx
+++ b/src/domains/Explore/components/ranking/UserTotalRanking.tsx
@@ -1,220 +1,28 @@
-import RankingList from './RankingList';
-import RankingPodium from './RankingPodium';
+import { useEffect, useState } from 'react';
+import RankingList from '@/domains/Explore/components/ranking/RankingList';
+import RankingPodium from '@/domains/Explore/components/ranking/RankingPodium';
+import { getUserRank } from '@/domains/Explore/api/rank';
 
 export type UserRank = {
   rank: number;
   nickname: string;
   title: string;
-  completion: string;
+  completePercentage: string;
   level: number;
-  benefitCount: number;
+  storeUsage: number;
 };
 
-// 임의 데이터
-const rankList: UserRank[] = [
-  {
-    rank: 1,
-    nickname: 'korea154_1',
-    title: '절약 고수',
-    completion: '56%',
-    level: 40,
-    benefitCount: 585,
-  },
-  {
-    rank: 2,
-    nickname: 'happy140_2',
-    title: '신입 유저',
-    completion: '99%',
-    level: 90,
-    benefitCount: 607,
-  },
-  {
-    rank: 3,
-    nickname: 'mint367_3',
-    title: '미션 전문가',
-    completion: '44%',
-    level: 6,
-    benefitCount: 972,
-  },
-  {
-    rank: 4,
-    nickname: 'delta951_4',
-    title: '알뜰러',
-    completion: '41%',
-    level: 2,
-    benefitCount: 997,
-  },
-  {
-    rank: 5,
-    nickname: 'neo170_5',
-    title: '모범 유저',
-    completion: '78%',
-    level: 99,
-    benefitCount: 914,
-  },
-  {
-    rank: 6,
-    nickname: 'mint374_6',
-    title: '기록형 유저',
-    completion: '46%',
-    level: 63,
-    benefitCount: 557,
-  },
-  {
-    rank: 7,
-    nickname: 'alpha207_7',
-    title: '혜택 헌터',
-    completion: '95%',
-    level: 34,
-    benefitCount: 123,
-  },
-  {
-    rank: 8,
-    nickname: 'korea944_8',
-    title: '랭킹 챌린저',
-    completion: '79%',
-    level: 14,
-    benefitCount: 273,
-  },
-  {
-    rank: 9,
-    nickname: 'light611_9',
-    title: '기록형 유저',
-    completion: '60%',
-    level: 28,
-    benefitCount: 733,
-  },
-  {
-    rank: 10,
-    nickname: 'saver779_10',
-    title: '혜택 헌터',
-    completion: '84%',
-    level: 28,
-    benefitCount: 414,
-  },
-  {
-    rank: 11,
-    nickname: 'neo811_11',
-    title: '도감 수집러',
-    completion: '96%',
-    level: 33,
-    benefitCount: 346,
-  },
-  {
-    rank: 12,
-    nickname: 'saver291_12',
-    title: '알뜰러',
-    completion: '50%',
-    level: 53,
-    benefitCount: 564,
-  },
-  {
-    rank: 13,
-    nickname: 'delta832_13',
-    title: '절약 고수',
-    completion: '80%',
-    level: 27,
-    benefitCount: 355,
-  },
-  {
-    rank: 14,
-    nickname: 'alpha465_14',
-    title: '기록형 유저',
-    completion: '76%',
-    level: 64,
-    benefitCount: 782,
-  },
-  {
-    rank: 15,
-    nickname: 'delta963_15',
-    title: '혜택 수집가',
-    completion: '77%',
-    level: 25,
-    benefitCount: 165,
-  },
-  {
-    rank: 16,
-    nickname: 'light243_16',
-    title: '모범 유저',
-    completion: '53%',
-    level: 8,
-    benefitCount: 290,
-  },
-  {
-    rank: 17,
-    nickname: 'korea800_17',
-    title: '혜택 수집가',
-    completion: '83%',
-    level: 26,
-    benefitCount: 834,
-  },
-  {
-    rank: 18,
-    nickname: 'delta250_18',
-    title: '베테랑',
-    completion: '45%',
-    level: 33,
-    benefitCount: 572,
-  },
-  {
-    rank: 19,
-    nickname: 'user295_19',
-    title: '절약 고수',
-    completion: '69%',
-    level: 30,
-    benefitCount: 908,
-  },
-  {
-    rank: 20,
-    nickname: 'neo348_20',
-    title: '혜택 헌터',
-    completion: '74%',
-    level: 9,
-    benefitCount: 189,
-  },
-  {
-    rank: 21,
-    nickname: 'korea872_21',
-    title: '탐험가',
-    completion: '48%',
-    level: 36,
-    benefitCount: 822,
-  },
-  {
-    rank: 22,
-    nickname: 'korea103_22',
-    title: '신의 한수',
-    completion: '41%',
-    level: 94,
-    benefitCount: 277,
-  },
-  {
-    rank: 23,
-    nickname: 'light182_23',
-    title: '혜택 수집가',
-    completion: '50%',
-    level: 19,
-    benefitCount: 321,
-  },
-  {
-    rank: 24,
-    nickname: 'alpha280_24',
-    title: '미션 전문가',
-    completion: '56%',
-    level: 24,
-    benefitCount: 678,
-  },
-  {
-    rank: 25,
-    nickname: 'mint676_25',
-    title: '절약 고수',
-    completion: '89%',
-    level: 93,
-    benefitCount: 935,
-  },
-];
-
 const UserTotalRanking = () => {
+  const [rankList, setRankList] = useState<UserRank[]>([]);
+
+  useEffect(() => {
+    const fetchUserRank = async () => {
+      const userRank = await getUserRank();
+      setRankList(userRank);
+    };
+    fetchUserRank();
+  }, []);
+
   if (!rankList || rankList.length === 0) {
     return (
       <div className="text-center text-gray-400">
@@ -224,7 +32,7 @@ const UserTotalRanking = () => {
   }
 
   const podiumRanks = rankList
-    .filter((user) => user.rank >= 1 && user.rank <= 3)
+    .filter((_, i) => i + 1 >= 1 && i + 1 <= 3)
     .sort((a, b) => a.rank - b.rank)
     .map((user) => user.nickname);
 

--- a/src/domains/Explore/pages/RankingPage.tsx
+++ b/src/domains/Explore/pages/RankingPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import UserTotalRanking from '../components/ranking/UserTotalRanking';
-import UserStoreRanking from '../components/ranking/UserStoreRanking';
+import UserTotalRanking from '@/domains/Explore/components/ranking/UserTotalRanking';
+import StoreRanking from '@/domains/Explore/components/ranking/StoreRanking';
 
 type Tab = {
   title: string;
@@ -9,7 +9,7 @@ type Tab = {
 
 const tabs: Tab[] = [
   { title: '전체', content: <UserTotalRanking /> },
-  { title: '매장별', content: <UserStoreRanking /> },
+  { title: '매장별', content: <StoreRanking /> },
 ];
 
 const RankingPage = () => {

--- a/src/domains/Explore/pages/RankingPage.tsx
+++ b/src/domains/Explore/pages/RankingPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import UserTotalRanking from '@/domains/Explore/components/ranking/UserTotalRanking';
 import StoreRanking from '@/domains/Explore/components/ranking/StoreRanking';
+import { Breadcrumb } from '@/components/Breadcrumb';
 
 type Tab = {
   title: string;
@@ -17,8 +18,9 @@ const RankingPage = () => {
 
   return (
     <div className="w-full max-w-[1050px] m-6">
+      <Breadcrumb title="혜택탐험" subtitle="혜택 순위" />
       {/* 탭 버튼 */}
-      <div>
+      <div className="mt-3">
         {tabs.map((item, i) => (
           <button
             key={i}

--- a/src/domains/Explore/pages/SharePage.tsx
+++ b/src/domains/Explore/pages/SharePage.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useState, useMemo } from 'react';
 import { getBrands, getShareLocations, getSharePostList } from '../api/share';
 import CustomSelect from '../components/CustomSelect';
+import { Breadcrumb } from '@/components/Breadcrumb';
 
 const SharePage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
@@ -137,7 +138,9 @@ const SharePage = () => {
 
   return (
     <div className="w-full max-w-[1050px] m-6">
-      <h2 className="text-[32px] font-bold mb-4">혜택 나누기</h2>
+      <Breadcrumb title="혜택탐험" subtitle="혜택 나누기" />
+
+      <h2 className="text-[32px] font-bold mt-3 mb-4">혜택 나누기</h2>
 
       <div className="flex justify-between gap-4">
         <div className="flex gap-2 flex-1">

--- a/src/domains/Explore/types/rank.ts
+++ b/src/domains/Explore/types/rank.ts
@@ -1,0 +1,20 @@
+export type UserRank = {
+  rank: number;
+  nickname: string;
+  title: string;
+  completePercentage: string;
+  level: number;
+  storeUsage: number;
+};
+
+export type StoreRank = {
+  id: string;
+  name: string;
+  usageCount: number;
+  address: string;
+  category: string;
+  latitude: number;
+  longitude: number;
+  brandName: string;
+  brandImageUrl: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

> 이 변경사항과 관련된 이슈 번호를 명시합니다.  
> 예: #123, #456

- #120 

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 전체 사용자 랭킹 API 연동
2. 내 순위 스크롤 위치에 따라 상단/하단 고정 표시 기능 구현
3. title 태그 스타일 수정
4. 매장 순위 UI 초기 구현 및 API 연동
5. 페이지 상단에 Breadcrumb 컴포넌트 적용

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 전체 사용자 랭킹 데이터를 서버에서 받아와 리스트에 렌더링
- 자신의 닉네임이 랭킹 리스트에서 보이지 않을 경우, 스크롤 위치에 따라 상단 또는 하단에 고정 표시되도록 구현
- 사용자 칭호에 적용된 title 태그 스타일 개선
- 매장별 랭킹을 보여주는 UI 구조를 새롭게 구현하고, 초기 API 연동 처리
- Breadcrumb 컴포넌트 적용

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 아직 반응형은 구현하지 못했습니다 태그가 너무 길어지면 어떻게 해야 할지 고민입니다..
- 리스트 아이템에 border를 빼두었습니다

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.
![순위_PC](https://github.com/user-attachments/assets/84f9c4c2-fe32-4460-9453-d6a5ebfcbd8a)

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
