### PR TITLE
Refactor/explore rank 175

### DIFF
--- a/src/domains/Explore/components/ranking/RankingPodium.tsx
+++ b/src/domains/Explore/components/ranking/RankingPodium.tsx
@@ -8,25 +8,27 @@ const RankingPodium = ({ podiumRanks }: PodiumProps) => {
   const [first, second, third] = podiumRanks;
 
   return (
-    <div
-      className="relative w-full max-w-md mx-auto aspect-[472/312] bg-no-repeat bg-contain bg-center mt-10"
-      style={{ backgroundImage: `url(${podiumImage})` }}
-    >
-      {first && (
-        <div className="absolute -top-[9%] left-1/2 -translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center">
-          {first}
-        </div>
-      )}
-      {second && (
-        <div className="absolute top-[11%] left-[16%] -translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center">
-          {second}
-        </div>
-      )}
-      {third && (
-        <div className="absolute top-[14%] right-[16%] translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center">
-          {third}
-        </div>
-      )}
+    <div className="w-full pt-8 md:pt-14 md:pb-6 bg-white rounded-lg shadow-inner">
+      <div
+        className="relative w-full max-w-md mx-auto aspect-[472/312] bg-no-repeat bg-contain bg-center"
+        style={{ backgroundImage: `url(${podiumImage})` }}
+      >
+        {first && (
+          <div className="absolute -top-[9%] left-1/2 -translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center text-sm md:text-base">
+            {first}
+          </div>
+        )}
+        {second && (
+          <div className="absolute top-[11%] left-[16%] -translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center text-sm md:text-base">
+            {second}
+          </div>
+        )}
+        {third && (
+          <div className="absolute top-[14%] right-[16%] translate-x-1/2 font-bold truncate overflow-hidden whitespace-nowrap max-w-32 text-center text-sm md:text-base">
+            {third}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/domains/Explore/components/ranking/StoreRanking.tsx
+++ b/src/domains/Explore/components/ranking/StoreRanking.tsx
@@ -3,22 +3,40 @@ import { getStoreRank } from '@/domains/Explore/api/rank';
 import StoreRankingList from './StoreRankingList';
 import type { StoreRank } from '@/domains/Explore/types/rank';
 import TopRankSection from './StoreTopRank';
+import { Grid } from 'ldrs/react';
 
 const UserStoreRanking = () => {
   const [storeRankList, setStoreRankList] = useState<StoreRank[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchStoreRank = async () => {
-      const storeRank = await getStoreRank();
-      setStoreRankList(storeRank);
+      try {
+        const storeRank = await getStoreRank();
+        setStoreRankList(storeRank);
+      } catch (e) {
+        console.error('매장 순위 로딩 실패', e);
+      } finally {
+        setIsLoading(false);
+      }
     };
+
     fetchStoreRank();
   }, []);
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-100 flex flex-col justify-center items-center gap-4 text-gray-600">
+        <Grid size="100" speed="1.5" color="#6fc3d1" />
+        순위 데이터를 불러오고 있어요
+      </div>
+    );
+  }
 
   if (!storeRankList || storeRankList.length === 0) {
     return (
       <div className="text-center text-gray-400">
-        아직 랭킹 정보가 없습니다 💤
+        아직 순위 정보가 없습니다 💤
       </div>
     );
   }

--- a/src/domains/Explore/components/ranking/StoreRanking.tsx
+++ b/src/domains/Explore/components/ranking/StoreRanking.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getStoreRank } from '@/domains/Explore/api/rank';
 import StoreRankingList from './StoreRankingList';
 import type { StoreRank } from '@/domains/Explore/types/rank';
+import TopRankSection from './StoreTopRank';
 
 const UserStoreRanking = () => {
   const [storeRankList, setStoreRankList] = useState<StoreRank[]>([]);
@@ -21,7 +22,12 @@ const UserStoreRanking = () => {
       </div>
     );
   }
-  return <StoreRankingList rankList={storeRankList} />;
+  return (
+    <>
+      <TopRankSection topStores={storeRankList.slice(0, 3)} />
+      <StoreRankingList rankList={storeRankList} />
+    </>
+  );
 };
 
 export default UserStoreRanking;

--- a/src/domains/Explore/components/ranking/StoreRankingList.tsx
+++ b/src/domains/Explore/components/ranking/StoreRankingList.tsx
@@ -7,13 +7,14 @@ type StoreRankingListProps = {
   rankList: StoreRank[];
 };
 
+const rowClass = 'flex w-full px-4 py-4 items-center';
 const cellBaseClass = 'flex items-center justify-center';
 const columnClass = {
-  rank: `w-[10%] ${cellBaseClass} text-center font-bold`,
-  store: 'w-[35%] flex flex-wrap gap-x-4 gap-y-1 items-center',
-  category: `w-[15%] ${cellBaseClass} text-center`,
-  address: `w-[30%] ${cellBaseClass} text-sm text-left`,
-  usage: `w-[10%] ${cellBaseClass} text-center`,
+  rank: `flex-[1] ${cellBaseClass} text-center font-bold`,
+  store: `flex-[2] font-bold flex gap-x-4 gap-y-1 flex-wrap items-center min-w-0`,
+  category: `flex-[1.5] ${cellBaseClass} text-center `,
+  address: `flex-[1.5] ${cellBaseClass} text-center`,
+  usage: `flex-[1] ${cellBaseClass} text-center `,
 };
 
 const medals = [medalGold, medalSilver, medalBronze];
@@ -21,7 +22,9 @@ const medals = [medalGold, medalSilver, medalBronze];
 const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
   return (
     <>
-      <div className="mt-4 bg-[#E6F4F1] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-700 font-bold whitespace-normal">
+      <div
+        className={`${rowClass} mt-4 py-6 bg-[#E6F4F1] rounded-3xl text-gray-700 font-bold`}
+      >
         <div className={columnClass.rank}>순위</div>
         <div className={columnClass.store}>매장</div>
         <div className={columnClass.category}>카테고리</div>
@@ -33,13 +36,17 @@ const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
         {rankList.map((store, index) => (
           <li
             key={store.id}
-            className="flex sm:px-4 py-3.5 sm:py-4 justify-around items-center"
+            className={`${rowClass} text-sm sm:text-base flex sm:px-4 py-3.5 sm:py-4 justify-around items-center`}
           >
             <div className={columnClass.rank}>
               {index < 3 ? (
-                <img src={medals[index]} alt="메달" className="mx-auto" />
+                <img
+                  src={medals[index]}
+                  alt="메달"
+                  className="mx-auto sm:w-11 sm:h-11 w-8 h-8 object-contain"
+                />
               ) : (
-                <span className="text-xl">{index + 1}</span>
+                <span className="text-base sm:text-xl">{index + 1}</span>
               )}
             </div>
 
@@ -47,7 +54,7 @@ const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
               <img
                 src={store.brandImageUrl}
                 alt={store.brandName}
-                className="w-6 h-6 object-contain rounded"
+                className="w-6 h-6 sm:w-12 sm:h-12 object-contain rounded"
               />
               <span className="font-bold truncate whitespace-nowrap">
                 {store.name}

--- a/src/domains/Explore/components/ranking/StoreRankingList.tsx
+++ b/src/domains/Explore/components/ranking/StoreRankingList.tsx
@@ -23,7 +23,7 @@ const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
   return (
     <>
       <div
-        className={`${rowClass} mt-4 py-6 bg-[#E6F4F1] rounded-3xl text-gray-700 font-bold`}
+        className={`${rowClass} mt-4 py-6 bg-[#E6F4F1] rounded-3xl text-gray-600 font-bold`}
       >
         <div className={columnClass.rank}>순위</div>
         <div className={columnClass.store}>매장</div>

--- a/src/domains/Explore/components/ranking/StoreTopRank.tsx
+++ b/src/domains/Explore/components/ranking/StoreTopRank.tsx
@@ -70,17 +70,17 @@ const RankCard = ({ store, rank }: { store: StoreRank; rank: number }) => {
 
 const TopRankSection = ({ topStores }: { topStores: StoreRank[] }) => {
   return (
-    <div className="w-full py-8 md:py-12">
+    <div className="w-full py-8 md:py-12 bg-white rounded-lg shadow-inner">
       <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 md:gap-8 px-4">
-        {/* 모바일 */}
-        <div className="sm:hidden flex flex-col items-center gap-4 w-full">
+        {/* 모바일/태블릿 */}
+        <div className="lg:hidden flex flex-col items-center gap-4 w-full">
           <RankCard store={topStores[0]} rank={1} />
           <RankCard store={topStores[1]} rank={2} />
           <RankCard store={topStores[2]} rank={3} />
         </div>
 
-        {/* 태블릿/데스크톱 */}
-        <div className="hidden sm:flex flex-row items-center justify-center gap-4 md:gap-8">
+        {/* 데스크톱 */}
+        <div className="hidden lg:flex flex-row items-center justify-center gap-4 md:gap-8">
           <RankCard store={topStores[1]} rank={2} />
           <RankCard store={topStores[0]} rank={1} />
           <RankCard store={topStores[2]} rank={3} />

--- a/src/domains/Explore/components/ranking/StoreTopRank.tsx
+++ b/src/domains/Explore/components/ranking/StoreTopRank.tsx
@@ -1,0 +1,93 @@
+import type { StoreRank } from '../../types/rank';
+import { MapPin, BarChart3 } from 'lucide-react';
+
+const RankCard = ({ store, rank }: { store: StoreRank; rank: number }) => {
+  const cardStyles = {
+    1: 'bg-white transform scale-105 shadow-xl p-3 md:p-4',
+    2: 'bg-white shadow-lg p-3 md:p-4',
+    3: 'bg-white shadow-lg p-3 md:p-4',
+  };
+
+  const rankIconStyles = {
+    1: 'text-[#5AC5FF]',
+    2: 'text-[#A0D8F1]',
+    3: 'text-[#BEE9FF]',
+  };
+
+  return (
+    <div
+      className={`relative bg-white/95 backdrop-blur-xl rounded-2xl group transition-all duration-500 ease-out hover:-translate-y-2 w-full max-w-xs scale-95 min-h-[240px] sm:min-h-[260px] md:min-h-[280px] ${cardStyles[rank as keyof typeof cardStyles]}`}
+    >
+      <div className="flex flex-col h-full justify-between">
+        <div
+          className={`text-2xl sm:text-3xl font-bold ${rankIconStyles[rank as keyof typeof rankIconStyles]} mb-1`}
+        >
+          {rank}
+        </div>
+
+        {/* 브랜드 이미지 */}
+        <div className="flex justify-center mb-3">
+          <div className="w-10 h-10 sm:w-12 sm:h-12 md:w-13 md:h-13 rounded-xl bg-gradient-to-br border border-white/20 flex items-center justify-center text-white font-bold shadow-lg transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3">
+            <img
+              src={store.brandImageUrl}
+              alt={store.name}
+              className="w-10 h-10 sm:w-12 sm:h-12 md:w-13 md:h-13 rounded-xl"
+            />
+          </div>
+        </div>
+
+        {/* 매장 이름 */}
+        <div className="text-center mb-3 flex-shrink-0">
+          <h3 className="font-bold text-gray-800 mb-1 line-clamp-1 text-sm md:text-base">
+            {store.name}
+          </h3>
+          <span className="inline-block px-2 sm:px-3 py-0.5 rounded-full text-xs font-medium bg-gradient-to-r">
+            {store.category}
+          </span>
+        </div>
+
+        {/* 정보 섹션 */}
+        <div className="space-y-1 flex-1 flex flex-col justify-end">
+          <div className="flex items-center p-2 rounded-lg bg-gray-50/70">
+            <MapPin className="w-4 h-4 mr-2 flex-shrink-0" />
+            <span className="text-gray-700 text-xs leading-tight truncate">
+              {store.address}
+            </span>
+          </div>
+
+          <div className="flex items-center p-2 rounded-lg bg-gray-50/70">
+            <BarChart3 className="w-4 h-4 mr-2 flex-shrink-0" />
+            <span className="text-gray-700 text-xs">
+              이용횟수:{' '}
+              <span className="font-semibold">{store.usageCount}</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TopRankSection = ({ topStores }: { topStores: StoreRank[] }) => {
+  return (
+    <div className="w-full py-8 md:py-12">
+      <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 md:gap-8 px-4">
+        {/* 모바일 */}
+        <div className="sm:hidden flex flex-col items-center gap-4 w-full">
+          <RankCard store={topStores[0]} rank={1} />
+          <RankCard store={topStores[1]} rank={2} />
+          <RankCard store={topStores[2]} rank={3} />
+        </div>
+
+        {/* 태블릿/데스크톱 */}
+        <div className="hidden sm:flex flex-row items-center justify-center gap-4 md:gap-8">
+          <RankCard store={topStores[1]} rank={2} />
+          <RankCard store={topStores[0]} rank={1} />
+          <RankCard store={topStores[2]} rank={3} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TopRankSection;

--- a/src/domains/Explore/components/ranking/UserRankingList.tsx
+++ b/src/domains/Explore/components/ranking/UserRankingList.tsx
@@ -9,28 +9,75 @@ type RankingListProps = {
   rankList: UserRank[];
 };
 
-const cellBaseClass = 'flex items-center justify-center';
+const cellBase = 'flex items-center justify-center';
 const columnClass = {
-  rank: `w-[15%] ${cellBaseClass} text-center font-bold`,
-  nickname: 'w-[30%] flex flex-wrap gap-x-4 gap-y-1 items-center',
-  completion: `w-[20%] ${cellBaseClass} text-center`,
-  level: `w-[15%] ${cellBaseClass}`,
-  count: `w-[20%] ${cellBaseClass} text-center`,
+  rank: `flex-[1.5] ${cellBase} text-center font-bold`,
+  nickname: 'flex-[3] flex flex-wrap gap-x-4 gap-y-1 items-center',
+  completion: `flex-[2] ${cellBase} text-center`,
+  level: `flex-[1.5] ${cellBase}`,
+  count: `flex-[2] ${cellBase} text-center`,
 };
 
+const tagClass =
+  'shimmer text-[10px] sm:text-base px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap max-w-[6rem] sm:max-w-[11rem] overflow-hidden text-ellipsis';
+
 const medals = [medalGold, medalSilver, medalBronze];
+
+const RankRow = ({
+  user,
+  index,
+  isSticky,
+  isTopSticky,
+  refProp,
+}: {
+  user: UserRank;
+  index: number;
+  isSticky?: boolean;
+  isTopSticky?: boolean;
+  refProp?: React.RefObject<HTMLLIElement | null>;
+}) => {
+  const stickyClass = isSticky
+    ? `sticky ${isTopSticky ? 'top-15' : 'bottom-4'} bg-[#BBE3E6] rounded-2xl z-10`
+    : '';
+  return (
+    <li
+      ref={refProp}
+      className={`text-sm sm:text-base flex sm:px-4 py-3.5 sm:py-4 justify-around items-center ${stickyClass}`}
+    >
+      <div className={columnClass.rank}>
+        {index < 3 ? (
+          <img src={medals[index]} alt="메달" className="mx-auto" />
+        ) : (
+          <span className="text-xl">{index + 1}</span>
+        )}
+      </div>
+      <div className={columnClass.nickname}>
+        <span className="font-bold truncate overflow-hidden whitespace-nowrap max-w-[6rem] sm:max-w-[8rem]">
+          {user.nickname}
+        </span>
+        {user.title && <span className={tagClass}>{user.title}</span>}
+      </div>
+      <div className={columnClass.completion}>
+        {Number(user.completePercentage).toFixed(2).replace(/\.00$/, '')}%
+      </div>
+      <div className={columnClass.level}>Lv. {user.level}</div>
+      <div className={columnClass.count}>{user.storeUsage}회</div>
+    </li>
+  );
+};
 
 const UserRankingList = ({ rankList }: RankingListProps) => {
   const [myNickname, setMyNickname] = useState<string | null>(null);
   const [isPassedMyRank, setIsPassedMyRank] = useState(true);
+  const [isMyRankVisible, setIsMyRankVisible] = useState(false);
   const myRankRef = useRef<HTMLLIElement>(null);
+
+  const myRank = rankList.find((u) => u.nickname === myNickname);
+  const myIndex = rankList.findIndex((u) => u.nickname === myNickname);
 
   useEffect(() => {
     const token = localStorage.getItem('authToken');
-    if (!token) {
-      setMyNickname(null);
-      return;
-    }
+    if (!token) return setMyNickname(null);
 
     const fetchUser = async () => {
       try {
@@ -46,30 +93,33 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
   }, []);
 
   useEffect(() => {
-    if (!myRankRef.current) {
-      return;
-    }
+    if (!myRankRef.current) return;
 
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsMyRankVisible(entry.isIntersecting),
+      { threshold: 0.1 },
+    );
+
+    observer.observe(myRankRef.current);
+    return () => observer.disconnect();
+  }, [myNickname]);
+
+  useEffect(() => {
     const handleScroll = () => {
       if (!myRankRef.current) return;
-
       const rect = myRankRef.current.getBoundingClientRect();
       setIsPassedMyRank(rect.bottom < 100);
     };
+
     window.addEventListener('scroll', handleScroll);
-    // 초기 상태 체크
-    handleScroll();
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
+    handleScroll(); // 초기 상태 체크
+    return () => window.removeEventListener('scroll', handleScroll);
   }, [myNickname]);
-
-  const myRank = rankList.find((user) => user.nickname === myNickname);
 
   return (
     <>
-      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-700 font-bold break-keep whitespace-normal">
+      {/* 헤더 */}
+      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-600 font-bold break-keep whitespace-normal">
         <div className={columnClass.rank}>순위</div>
         <div className={columnClass.nickname}>닉네임</div>
         <div className={columnClass.completion}>도감 완성률</div>
@@ -77,78 +127,28 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
         <div className={columnClass.count}>혜택 받은 횟수</div>
       </div>
 
+      {/* 위에 고정된 내 순위 */}
       {myRank && isPassedMyRank && (
-        <div className="sticky top-15 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10">
-          <div className={columnClass.rank}>
-            {rankList.indexOf(myRank) < 3 ? (
-              <img
-                src={medals[rankList.indexOf(myRank)]}
-                alt="메달"
-                className="mx-auto"
-              />
-            ) : (
-              <span className="text-xl">{rankList.indexOf(myRank) + 1}</span>
-            )}
-          </div>
-          <div className={columnClass.nickname}>
-            <span className="font-bold truncate overflow-hidden whitespace-nowrap">
-              {myRank.nickname}
-            </span>
-            {myRank.title && (
-              <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
-                {myRank.title}
-              </span>
-            )}
-          </div>
-          <div className={columnClass.completion}>
-            {Number(myRank.completePercentage).toFixed(2).replace(/\.00$/, '')}%
-          </div>
-          <div className={columnClass.level}>Lv. {myRank.level}</div>
-          <div className={columnClass.count}>{myRank.storeUsage}회</div>
-        </div>
+        <RankRow user={myRank} index={myIndex} isSticky isTopSticky />
       )}
 
-      <ul>
+      {/* 전체 랭킹 */}
+      <ul className="mt-2 sm:mt-4 bg-white">
         {rankList.map((user, index) => (
-          <li
+          <RankRow
             key={index}
-            ref={user.nickname === myNickname ? myRankRef : null}
-            className={`flex sm:px-4 py-3.5 sm:py-4 justify-around items-center ${
-              user.nickname === myNickname && !isPassedMyRank
-                ? 'sticky bottom-4 bg-[#BBE3E6] rounded-2xl'
-                : ''
-            }`}
-          >
-            <div className={columnClass.rank}>
-              {index < 3 ? (
-                <img src={medals[index]} alt="메달" className="mx-auto" />
-              ) : (
-                <span className="text-xl">{index + 1}</span>
-              )}
-            </div>
-            <div className={columnClass.nickname}>
-              <span className="font-bold truncate overflow-hidden whitespace-nowrap">
-                {user.nickname}
-              </span>
-              {user.title && (
-                <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
-                  {user.title}
-                </span>
-              )}
-            </div>
-            <div className={columnClass.completion}>
-              <div className={columnClass.completion}>
-                {Number(user.completePercentage)
-                  .toFixed(2)
-                  .replace(/\.00$/, '')}
-                %
-              </div>
-            </div>
-            <div className={columnClass.level}>Lv. {user.level}</div>
-            <div className={columnClass.count}>{user.storeUsage}회</div>
-          </li>
+            user={user}
+            index={index}
+            refProp={user.nickname === myNickname ? myRankRef : undefined}
+            isSticky={user.nickname === myNickname && !isPassedMyRank}
+          />
         ))}
       </ul>
+
+      {/* 아래 고정된 내 순위 */}
+      {myRank && !isMyRankVisible && !isPassedMyRank && (
+        <RankRow user={myRank} index={myIndex} isSticky />
+      )}
     </>
   );
 };

--- a/src/domains/Explore/components/ranking/UserRankingList.tsx
+++ b/src/domains/Explore/components/ranking/UserRankingList.tsx
@@ -133,7 +133,7 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
       )}
 
       {/* 전체 랭킹 */}
-      <ul className="mt-2 sm:mt-4 bg-white">
+      <ul>
         {rankList.map((user, index) => (
           <RankRow
             key={index}

--- a/src/domains/Explore/components/ranking/UserTotalRanking.tsx
+++ b/src/domains/Explore/components/ranking/UserTotalRanking.tsx
@@ -3,22 +3,40 @@ import UserRankingList from '@/domains/Explore/components/ranking/UserRankingLis
 import RankingPodium from '@/domains/Explore/components/ranking/RankingPodium';
 import { getUserRank } from '@/domains/Explore/api/rank';
 import type { UserRank } from '@/domains/Explore/types/rank';
+import { Grid } from 'ldrs/react';
+import 'ldrs/react/Grid.css';
 
 const UserTotalRanking = () => {
   const [rankList, setRankList] = useState<UserRank[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchUserRank = async () => {
-      const userRank = await getUserRank();
-      setRankList(userRank);
+      try {
+        const userRank = await getUserRank();
+        setRankList(userRank);
+      } catch (e) {
+        console.error('전체 순위 불러오기 실패', e);
+      } finally {
+        setIsLoading(false);
+      }
     };
     fetchUserRank();
   }, []);
 
+  if (isLoading) {
+    return (
+      <div className="w-full h-100 flex flex-col justify-center items-center gap-4 text-gray-600">
+        <Grid size="100" speed="1.5" color="#6fc3d1" />
+        순위 데이터를 불러오고 있어요
+      </div>
+    );
+  }
+
   if (!rankList || rankList.length === 0) {
     return (
       <div className="text-center text-gray-400">
-        아직 랭킹 정보가 없습니다 💤
+        아직 순위 정보가 없습니다 💤
       </div>
     );
   }

--- a/src/domains/Explore/pages/RankingPage.tsx
+++ b/src/domains/Explore/pages/RankingPage.tsx
@@ -17,7 +17,7 @@ const RankingPage = () => {
   const [activeTab, setActiveTab] = useState(0);
 
   return (
-    <div className="w-full max-w-[1050px] m-6">
+    <div className="w-[calc(100%-48px)] md:w-[80%] max-w-[1050px] mb-50 md:mb-100">
       <Breadcrumb title="혜택탐험" subtitle="혜택 순위" />
       {/* 탭 버튼 */}
       <div className="mt-3">

--- a/src/domains/Explore/pages/RankingPage.tsx
+++ b/src/domains/Explore/pages/RankingPage.tsx
@@ -28,7 +28,7 @@ const RankingPage = () => {
             className={`relative cursor-pointer px-5 py-2.5 font-bold text-xl ${activeTab === i ? 'text-[#1CB0F7]' : 'text-gray-300'}`}
           >
             {item.title} 순위
-            <span className="absolute bottom-0 left-0 h-[1px] w-full bg-gray-300" />
+            <span className="absolute bottom-0 left-0 h-[1px] w-full " />
             <span
               className={`absolute bottom-0 h-0.5 transition-all duration-400 bg-[#1CB0F7] ${activeTab === i ? 'left-0 w-full translate-x-0' : 'left-1/2 w-0 -translate-x-1/2'}`}
             />

--- a/src/domains/Explore/pages/ShareDetailPage.tsx
+++ b/src/domains/Explore/pages/ShareDetailPage.tsx
@@ -84,8 +84,8 @@ const ShareDetailPage = () => {
   };
 
   return (
-    <>
-      <div className="w-full max-w-[1050px] m-6 flex flex-col gap-5">
+    <div className="w-[calc(100%-48px)] md:w-[80%] max-w-[1050px] mb-50 md:mb-100">
+      <div className="flex flex-col gap-5">
         <div className="flex gap-4 sm:items-center">
           <div className="relative w-16 h-16 sm:w-32 sm:h-32 flex items-center justify-center flex-shrink-0">
             {post.brandImgUrl ? (
@@ -188,7 +188,7 @@ const ShareDetailPage = () => {
           </>
         }
       ></Modal>
-    </>
+    </div>
   );
 };
 

--- a/src/domains/Explore/pages/SharePage.tsx
+++ b/src/domains/Explore/pages/SharePage.tsx
@@ -170,7 +170,7 @@ const SharePage = () => {
   };
 
   return (
-    <div className="w-full max-w-[1050px] m-6">
+    <div className="w-[calc(100%-48px)] md:w-[80%] max-w-[1050px] mb-50 md:mb-100">
       <Breadcrumb title="혜택탐험" subtitle="혜택 나누기" />
 
       <h2 className="text-[32px] font-bold mt-3 mb-4">혜택 나누기</h2>


### PR DESCRIPTION
## 🔗 관련 이슈

> 이 변경사항과 관련된 이슈 번호를 명시합니다.  
> 예: #123, #456

- #175 

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 매장 순위 TopRank 섹션 추가
2. 전체 순위/매장 순위 style 통일 및 반응형 대응
3. Ranking 페이지 레이아웃 수정
4. 순위 데이터 로딩 상태 표시
5. 게시글 목록 및 상세 페이지 레이아웃 개선

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- StoreTopRank 컴포넌트를 통해 1~3위 매장을 상단 강조 UI로 분리
- UserRanking과 UserStoreRanking의 스타일 구조를 통일하고 모바일 환경에서도 적절히 대응되도록 수정
- Ranking 페이지 내 레이아웃 패딩/마진 구조 및 정렬 방식 개선
- 순위 데이터를 불러오는 동안 로딩 UI(Grid 컴포넌트) 표시
- 게시글 목록과 상세 페이지 내 간격 및 정렬을 조정하여 시각적 일관성 향상



## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 로딩 상태에서 Grid 애니메이션이 정상 작동하는지 확인해주세요.
- 반응형에서 TopRank 레이아웃이 잘 맞춰지는지 검토 부탁드립니다.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
