### PR TITLE
Refactor/chat share 187

### DIFF
--- a/src/domains/Chat/api/chat.ts
+++ b/src/domains/Chat/api/chat.ts
@@ -20,3 +20,13 @@ export const getChatMessages = async (chatRoomId: string) => {
 
   return response.data;
 };
+
+export const leaveChatRoom = async (chatRoomId: string) => {
+  const token = localStorage.getItem('authToken');
+  const response = await axios.delete(`${baseURL}/user/chatRoom`, {
+    params: { chatRoomId },
+    headers: { Authorization: token },
+  });
+
+  return response.data;
+};

--- a/src/domains/Chat/components/ChatRoomList.tsx
+++ b/src/domains/Chat/components/ChatRoomList.tsx
@@ -37,8 +37,15 @@ const ChatRoomList = ({
               >
                 <div className="flex items-center gap-3 p-4">
                   {/* 프로필 이미지 */}
-                  <div className="w-12 h-12 rounded object-cover bg-gray-300"></div>
-
+                  {room.postResponseDto.brandImgUrl ? (
+                    <img
+                      src={room.postResponseDto.brandImgUrl}
+                      alt="브랜드이미지"
+                      className="w-12 h-12 rounded object-cover"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 rounded object-cover bg-gray-300"></div>
+                  )}
                   {/* 채팅방 정보 */}
                   <div className="flex-1 min-w-0">
                     <div className="flex justify-between items-center mb-1">

--- a/src/domains/Chat/hooks/useWebSocket.ts
+++ b/src/domains/Chat/hooks/useWebSocket.ts
@@ -37,7 +37,6 @@ const useChatSocket = (roomId: string, senderId: string) => {
     socketRef.current = socket;
 
     socket.onopen = () => {
-      console.log('웹소켓 연결 성공');
       socket.send(
         JSON.stringify({
           type: 'join',
@@ -50,7 +49,6 @@ const useChatSocket = (roomId: string, senderId: string) => {
     socket.onmessage = (event) => {
       try {
         const msg = JSON.parse(event.data);
-        console.log('메시지 수신:', msg);
 
         const msgWithTime = {
           ...msg,
@@ -61,10 +59,6 @@ const useChatSocket = (roomId: string, senderId: string) => {
       } catch (e) {
         console.error('메시지 파싱 실패:', e);
       }
-    };
-
-    socket.onclose = () => {
-      console.log('웹소켓 연결 종료');
     };
 
     socket.onerror = (error) => {

--- a/src/domains/Chat/pages/ChatContent.tsx
+++ b/src/domains/Chat/pages/ChatContent.tsx
@@ -8,6 +8,8 @@ import {
   convertTimeFormat,
   fromISOStringToDateTime,
 } from '@/domains/Explore/utils/datetimeUtils';
+import { leaveChatRoom } from '../api/chat';
+import toast from 'react-hot-toast';
 
 const ChatContent = ({
   chatRooms,
@@ -15,12 +17,14 @@ const ChatContent = ({
   currentUser,
   isMobile = false,
   onBackToList,
+  onLeaveRoom,
 }: {
   chatRooms: ChatRoom[];
   selectedRoomId: string;
   currentUser: { id: string; name?: string };
   isMobile?: boolean;
   onBackToList?: () => void;
+  onLeaveRoom?: (roomId: string) => void;
 }) => {
   const navigate = useNavigate();
   const [messageInput, setMessageInput] = useState('');
@@ -77,6 +81,19 @@ const ChatContent = ({
     );
   }
 
+  // 대화방 나가기
+  const handleLeaveRoom = async () => {
+    try {
+      await leaveChatRoom(selectedRoomId);
+      toast('대화방에서 나갔습니다', { duration: 2000 });
+      setMenuOpen(false);
+      onLeaveRoom?.(selectedRoomId);
+    } catch (error) {
+      console.error('대화방 나가기 실패:', error);
+      toast.error('대화방 나가기에 실패했습니다', { duration: 2000 });
+    }
+  };
+
   const { title, author, location, promiseDate, postId, brandImgUrl } =
     selectedRoom.postResponseDto;
 
@@ -87,7 +104,7 @@ const ChatContent = ({
       className={`flex flex-col h-full ${isMobile ? 'w-full' : 'flex-1'} sm:max-w-[1050px]`}
     >
       {/* 채팅방 헤더 */}
-      <div className="relative border-b border-gray-200 px-4 py-4 shadow-sm flex flex-col gap-3">
+      <div className="relative border-b border-gray-200 px-4 py-4 shadow-sm flex sm:flex-col items-start gap-3">
         {/* 모바일에서만 뒤로가기 버튼 표시 */}
         {isMobile && onBackToList && (
           <button
@@ -97,9 +114,10 @@ const ChatContent = ({
             <ArrowLeft className="w-5 h-5 text-gray-600" />
           </button>
         )}
-        <div className="flex gap-4 justify-between items-start">
-          {/* 프로필 이미지 */}
-          <div className="flex gap-4">
+        <div className="flex justify-between items-start w-full gap-4">
+          {/* 왼쪽 영역: 브랜드 + 정보 + 버튼 */}
+          <div className="flex flex-row sm:flex-row gap-4 flex-1">
+            {/* 브랜드 이미지 */}
             {brandImgUrl ? (
               <img
                 src={brandImgUrl}
@@ -109,8 +127,9 @@ const ChatContent = ({
             ) : (
               <div className="w-12 h-12 sm:w-20 sm:h-20 rounded object-cover bg-gray-300"></div>
             )}
-            {/* 채팅방 정보 */}
-            <div className="min-w-0">
+
+            {/* 텍스트 정보 + 게시물 버튼 */}
+            <div className="flex flex-col gap-1 min-w-0">
               <h2 className="font-semibold text-lg text-gray-900 truncate">
                 {title}
               </h2>
@@ -118,18 +137,19 @@ const ChatContent = ({
                 <span>{author.nickname}</span>·<span>{location}</span>·
                 <span>{`${promiseDateObj.date}, ${promiseDateObj.time.period} ${promiseDateObj.time.hour}:${promiseDateObj.time.minute}`}</span>
               </p>
-            </div>
-            {/* 게시물 바로가기 버튼 */}
-            <div ref={dropdownRef}>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => navigate(`/explore/share/${postId}`)}
-              >
-                게시물 바로가기
-              </Button>
+              <div className="mt-2 sm:mt-0">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => navigate(`/explore/share/${postId}`)}
+                >
+                  게시물 바로가기
+                </Button>
+              </div>
             </div>
           </div>
+
+          {/* 우측 상단 메뉴 버튼 */}
           <button
             onClick={() => setMenuOpen((prev) => !prev)}
             className="p-2 rounded hover:bg-gray-100"
@@ -139,10 +159,7 @@ const ChatContent = ({
           {menuOpen && (
             <ul className="absolute right-6 top-12 w-40 bg-white border border-gray-200 rounded shadow-lg z-10">
               <li
-                onClick={() => {
-                  alert('대화방에서 나갔습니다.');
-                  setMenuOpen(false);
-                }}
+                onClick={handleLeaveRoom}
                 className="px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer"
               >
                 대화방 나가기
@@ -198,7 +215,7 @@ const ChatContent = ({
         )}
       </div>
 
-      <div className="flex gap-2 border border-gray-200 rounded-3xl py-3 px-4 mb-4 sm:mb-0 ml-4 mr-4">
+      <div className="flex gap-2 border border-gray-200 rounded-3xl py-2 px-3 sm:py-3 sm:px-4 mb-4 sm:mb-0 ml-4 mr-4">
         <input
           type="text"
           className="flex-1 border-none outline-none"

--- a/src/domains/Chat/pages/ChatPage.tsx
+++ b/src/domains/Chat/pages/ChatPage.tsx
@@ -128,6 +128,12 @@ const ChatPage = () => {
     navigate('/chat');
   };
 
+  const handleLeaveRoom = (roomId: string) => {
+    setChatRooms((prev) => prev.filter((room) => room.chatRoomId !== roomId));
+    setSelectedRoomId(null);
+    navigate('/chat');
+  };
+
   if (!currentUser) {
     return (
       <div className="flex justify-center items-center h-[calc(100vh-110px)]">
@@ -154,6 +160,7 @@ const ChatPage = () => {
               currentUser={currentUser}
               isMobile={isMobile}
               onBackToList={handleBackToList}
+              onLeaveRoom={handleLeaveRoom}
             />
           )
         )}
@@ -181,6 +188,7 @@ const ChatPage = () => {
           chatRooms={chatRooms}
           selectedRoomId={selectedRoomId}
           currentUser={currentUser}
+          onLeaveRoom={handleLeaveRoom}
         />
       ) : (
         <div className="flex-1 flex items-center justify-center">

--- a/src/domains/Chat/pages/ChatPage.tsx
+++ b/src/domains/Chat/pages/ChatPage.tsx
@@ -8,6 +8,7 @@ import ChatContent from './ChatContent';
 import ChatRoomList from '../components/ChatRoomList';
 import { Button } from '@/components/Button';
 import dolphinFind from '@/assets/image/dolphin_find.png';
+import { Grid } from 'ldrs/react';
 
 const ChatPage = () => {
   const location = useLocation();
@@ -23,6 +24,9 @@ const ChatPage = () => {
   const [isMobile, setIsMobile] = useState(false);
   const [showChatList, setShowChatList] = useState(true);
 
+  const [isUserLoading, setIsUserLoading] = useState(true);
+  const [isChatRoomLoading, setIsChatRoomLoading] = useState(true);
+
   // 화면 크기 감지
   useEffect(() => {
     const checkScreenSize = () => {
@@ -32,7 +36,6 @@ const ChatPage = () => {
         setShowChatList(true);
       }
     };
-
     checkScreenSize();
     window.addEventListener('resize', checkScreenSize);
     return () => window.removeEventListener('resize', checkScreenSize);
@@ -41,66 +44,75 @@ const ChatPage = () => {
   // 유저 정보 로딩
   useEffect(() => {
     const fetchUser = async () => {
-      const user = await getUserInfo();
-      setCurrentUser({
-        id: user.data.id,
-        name: user.data.name,
-      });
+      try {
+        const user = await getUserInfo();
+        setCurrentUser({
+          id: user.data.id,
+          name: user.data.name,
+        });
+      } catch (e) {
+        console.error('유저 정보 로딩 실패:', e);
+      } finally {
+        setIsUserLoading(false);
+      }
     };
     fetchUser();
   }, []);
 
-  // 채팅방 목록 + 쿼리에서 roomId 읽기
+  // 채팅방 목록 + 메시지
   useEffect(() => {
     const fetchChatRooms = async () => {
-      const data = await getChatRooms();
-      const rooms = data.data;
+      try {
+        const data = await getChatRooms();
+        const rooms = data.data;
 
-      const messagesByRoom: Record<string, Message[]> = {};
-      await Promise.all(
-        rooms.map(async (room: ChatRoom) => {
-          const res = await getChatMessages(room.chatRoomId);
-          messagesByRoom[room.chatRoomId] = res.data;
-        }),
-      );
+        const messagesByRoom: Record<string, Message[]> = {};
+        await Promise.all(
+          rooms.map(async (room: ChatRoom) => {
+            const res = await getChatMessages(room.chatRoomId);
+            messagesByRoom[room.chatRoomId] = res.data;
+          }),
+        );
 
-      const processedRooms = rooms.map((room: ChatRoom) => {
-        const roomMessages = messagesByRoom[room.chatRoomId] || [];
-        const lastMessage = roomMessages[0];
-        if (!lastMessage) {
+        const processedRooms = rooms.map((room: ChatRoom) => {
+          const roomMessages = messagesByRoom[room.chatRoomId] || [];
+          const lastMessage = roomMessages[0];
           return {
             ...room,
-            lastMessage: '',
-            lastMessageTime: '',
+            lastMessage: lastMessage?.message ?? '',
+            lastMessageTime: lastMessage?.time ?? '',
           };
-        }
-        return {
-          ...room,
-          lastMessage: lastMessage?.message ?? '',
-          lastMessageTime: lastMessage?.time ?? '',
-        };
-      });
+        });
 
-      setChatRooms(processedRooms);
+        setChatRooms(processedRooms);
 
-      const params = new URLSearchParams(location.search);
-      const roomIdFromURL = params.get('roomId');
-
-      if (roomIdFromURL) {
-        setSelectedRoomId(roomIdFromURL);
-        if (isMobile) {
-          setShowChatList(false);
+        const params = new URLSearchParams(location.search);
+        const roomIdFromURL = params.get('roomId');
+        if (roomIdFromURL) {
+          setSelectedRoomId(roomIdFromURL);
+          if (isMobile) setShowChatList(false);
+        } else {
+          setSelectedRoomId(null);
+          if (isMobile) setShowChatList(true);
         }
-      } else {
-        setSelectedRoomId(null);
-        if (isMobile) {
-          setShowChatList(true);
-        }
+      } catch (e) {
+        console.error('채팅방 로딩 실패:', e);
+      } finally {
+        setIsChatRoomLoading(false);
       }
     };
 
     fetchChatRooms();
   }, [location.search, navigate, isMobile]);
+
+  if (isUserLoading || isChatRoomLoading) {
+    return (
+      <div className="flex flex-col gap-4 justify-center items-center h-[calc(100vh-110px)] text-gray-500 animate-pulse">
+        <Grid size="100" speed="1.5" color="#6fc3d1" />
+        채팅 정보를 불러오고 있어요...
+      </div>
+    );
+  }
 
   const handleRoomSelect = (roomId: string) => {
     setSelectedRoomId(roomId);

--- a/src/domains/Explore/api/share.ts
+++ b/src/domains/Explore/api/share.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Post, PostWriteRequest } from '../types/share';
+import type { Post, PostWriteRequest, Store } from '../types/share';
 
 const baseURL = import.meta.env.VITE_API_URL;
 
@@ -86,4 +86,24 @@ export const createChatRoom = async (postId: string) => {
   );
 
   return response.data;
+};
+
+export const getNearbyStores = async (
+  category: string,
+  latitude: number,
+  longitude: number,
+  latRange = 0.02,
+  lngRange = 0.02,
+): Promise<Store[]> => {
+  const response = await axios.get(`${baseURL}/map/store`, {
+    params: {
+      category,
+      latMin: latitude - latRange,
+      latMax: latitude + latRange,
+      lngMin: longitude - lngRange,
+      lngMax: longitude + lngRange,
+    },
+  });
+
+  return Array.isArray(response.data.data) ? response.data.data : [];
 };

--- a/src/domains/Explore/components/CustomSelect.tsx
+++ b/src/domains/Explore/components/CustomSelect.tsx
@@ -143,7 +143,13 @@ const CustomSelect = ({
 
   return (
     <div className="relative text-gray-600" ref={selectRef}>
-      <div className="rounded-2xl border border-gray-200 p-3">
+      <div
+        className={`rounded-2xl border p-3 ${
+          disabled
+            ? 'bg-gray-100 border-gray-200 text-gray-400 cursor-'
+            : 'border-gray-200 text-gray-600'
+        }`}
+      >
         <button
           onClick={() => {
             if (type === 'single' && (!options || options.length === 0)) return;

--- a/src/domains/Explore/components/share/PlaceField.tsx
+++ b/src/domains/Explore/components/share/PlaceField.tsx
@@ -1,18 +1,23 @@
+import { Button } from '@/components/Button';
+import type { Store } from '../../types/share';
+
 interface PlaceFieldProps {
-  place: string;
-  setPlace: (place: string) => void;
+  selectedStore: Store | null;
+  onOpen: () => void;
 }
 
-const PlaceField = ({ place, setPlace }: PlaceFieldProps) => {
+const PlaceField = ({ selectedStore, onOpen }: PlaceFieldProps) => {
   return (
-    <div className="mb-6">
+    <div className="mb-6 flex gap-1 items-center">
       <label className="mr-2 font-bold">장소</label>
-      <input
-        value={place}
-        onChange={(e) => setPlace(e.target.value)}
-        placeholder="미정"
-        className="border p-3 rounded-2xl w-60 border-gray-200"
-      />
+      <div className="flex gap-2 items-center">
+        <span className="text-gray-800 font-medium rounded-2xl p-3 border border-gray-200">
+          {selectedStore?.name || '선택된 장소 없음'}
+        </span>
+      </div>
+      <Button onClick={onOpen} variant="ghost">
+        장소 선택
+      </Button>
     </div>
   );
 };

--- a/src/domains/Explore/components/share/SelectStoreModal.tsx
+++ b/src/domains/Explore/components/share/SelectStoreModal.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import type { Store } from '../../types/share';
+import { Button } from '@/components/Button';
+import { Modal } from '@/components/Modal';
+import { getNearbyStores } from '../../api/share';
+
+interface SelectStoreModalProps {
+  category: string | null;
+  brand: string | null;
+  onClose: () => void;
+  onSelect: (store: Store) => void;
+}
+
+const SelectStoreModal = ({
+  category,
+  brand,
+  onClose,
+  onSelect,
+}: SelectStoreModalProps) => {
+  const [stores, setStores] = useState<Store[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!category || !brand) {
+      setError('카테고리와 브랜드를 먼저 선택해주세요.');
+      setLoading(false);
+      return;
+    }
+
+    if (!navigator.geolocation) {
+      setError('위치 정보를 가져올 수 없습니다.');
+      setLoading(false);
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const { latitude, longitude } = position.coords;
+
+        try {
+          const rawStores = await getNearbyStores(
+            category,
+            latitude,
+            longitude,
+          );
+
+          const filtered = rawStores.filter(
+            (store) =>
+              store.brandName.trim().toLowerCase() ===
+              brand.trim().toLowerCase(),
+          );
+
+          setStores(filtered);
+        } catch (err) {
+          setError((err as Error).message);
+        } finally {
+          setLoading(false);
+        }
+      },
+      () => {
+        setError('위치 정보 접근이 거부되었습니다.');
+        setLoading(false);
+      },
+    );
+  }, [category, brand]);
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      title="주변 매장 선택"
+      description={
+        error
+          ? error
+          : loading
+            ? '위치 기반 매장을 불러오는 중입니다...'
+            : stores.length === 0
+              ? `주변에 ${brand} 매장이 없습니다.`
+              : undefined
+      }
+      actions={
+        <Button variant="secondary" onClick={onClose} className="w-full">
+          닫기
+        </Button>
+      }
+    >
+      {!loading && !error && stores.length > 0 && (
+        <ul className="max-h-90 overflow-y-auto divide-y divide-gray-200">
+          {stores.map((store) => (
+            <li
+              key={store.id}
+              onClick={() => {
+                onSelect(store);
+                onClose();
+              }}
+              className="cursor-pointer py-4 hover:bg-gray-100 px-2"
+            >
+              <p className="font-medium">{store.name}</p>
+              <p className="text-sm text-gray-500">{store.address}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
+  );
+};
+
+export default SelectStoreModal;

--- a/src/domains/Explore/components/share/SharePostItem.tsx
+++ b/src/domains/Explore/components/share/SharePostItem.tsx
@@ -100,7 +100,7 @@ const SharePostItem = ({ post }: SharePostItemProps) => {
             {`${dateTime.date}, ${dateTime.time.period} ${dateTime.time.hour}:${dateTime.time.minute}`}
           </div>
           <div className="flex items-center gap-2">
-            <MapPin size={20} /> {post.location}
+            <MapPin size={20} /> {post.storeName}
           </div>
         </div>
       </li>

--- a/src/domains/Explore/pages/ShareDetailPage.tsx
+++ b/src/domains/Explore/pages/ShareDetailPage.tsx
@@ -114,7 +114,7 @@ const ShareDetailPage = () => {
                 {`${dateTime.date}, ${dateTime.time.period} ${dateTime.time.hour}:${dateTime.time.minute}`}
               </div>
               <div className="text-gray-500 flex gap-1">
-                <MapPin size={20} /> {post.location}
+                <MapPin size={20} /> {post.storeName}
               </div>
             </div>
             <div className="text-gray-400">

--- a/src/domains/Explore/pages/SharePage.tsx
+++ b/src/domains/Explore/pages/SharePage.tsx
@@ -240,8 +240,8 @@ const SharePage = () => {
           <SharePostList posts={filteredPostList} />
           {hasNextPage && (
             <div className="text-center mt-6">
-              <button
-                className="bg-blue-500 text-white px-4 py-2 rounded"
+              <Button
+                variant="ghost"
                 onClick={() => {
                   const nextPage = page + 1;
                   setPage(nextPage);
@@ -249,7 +249,7 @@ const SharePage = () => {
                 }}
               >
                 더보기
-              </button>
+              </Button>
             </div>
           )}
         </>

--- a/src/domains/Explore/pages/SharePage.tsx
+++ b/src/domains/Explore/pages/SharePage.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { getBrands, getShareLocations, getSharePostList } from '../api/share';
 import CustomSelect from '../components/CustomSelect';
 import { Breadcrumb } from '@/components/Breadcrumb';
+import { shortenProvince } from '../utils/addressUtils';
 
 const SharePage = () => {
   const [postList, setPostList] = useState<Post[]>([]);
@@ -62,7 +63,7 @@ const SharePage = () => {
       try {
         setIsLoading(true);
         const locationsData = (await getShareLocations()).map((item) => ({
-          label: item,
+          label: shortenProvince(item),
           value: item,
         }));
 
@@ -118,7 +119,7 @@ const SharePage = () => {
 
   const filteredPostList = useMemo(() => {
     return postList.filter((post) => {
-      const matchLocation = location ? post.location === location.label : true;
+      const matchLocation = location ? post.location === location.value : true;
       const matchCategory = category ? post.category === category.label : true;
       const matchBrand = brand ? post.brandName === brand.label : true;
       const matchBenefit = benefit ? post.benefitName === benefit.label : true;

--- a/src/domains/Explore/pages/ShareWritePage.tsx
+++ b/src/domains/Explore/pages/ShareWritePage.tsx
@@ -5,7 +5,12 @@ import {
   getTodayString,
   toISOStringFromDateTime,
 } from '../utils/datetimeUtils';
-import type { PostWriteRequest, SelectOption, TimeValue } from '../types/share';
+import type {
+  PostWriteRequest,
+  SelectOption,
+  Store,
+  TimeValue,
+} from '../types/share';
 import SelectFields from '../components/share/SelectFields';
 import PostContentFields from '../components/share/PostContentFields';
 import DateTimePicker from '../components/share/DateTimePicker';
@@ -13,6 +18,8 @@ import PlaceField from '../components/share/PlaceField';
 import { createSharePost } from '../api/share';
 import { useNavigate } from 'react-router-dom';
 import { useUnsavedChanges } from '../../../contexts/UnsavedChangesContext';
+import SelectStoreModal from '../components/share/SelectStoreModal';
+import toast from 'react-hot-toast';
 
 const ShareWritePage = () => {
   const navigate = useNavigate();
@@ -35,6 +42,8 @@ const ShareWritePage = () => {
     place: '',
     time: getDefaultTime(),
   }));
+  const [selectedStore, setSelectedStore] = useState<Store | null>(null);
+  const [showModal, setShowModal] = useState(false);
 
   const { setHasUnsavedChanges } = useUnsavedChanges();
 
@@ -77,9 +86,21 @@ const ShareWritePage = () => {
       !title ||
       !content ||
       !date ||
-      !time
+      !time ||
+      !selectedStore
     ) {
-      alert('모든 항목을 입력해주세요.');
+      toast.error(<span>모든 항목을 입력해주세요.</span>, {
+        duration: 2000,
+        style: {
+          border: '1px solid #ebebeb',
+          padding: '16px',
+          color: '#e94e4e',
+        },
+        iconTheme: {
+          primary: '#e94e4e',
+          secondary: '#FFFAEE',
+        },
+      });
       return;
     }
 
@@ -90,7 +111,7 @@ const ShareWritePage = () => {
       title,
       content,
       promiseDate: toISOStringFromDateTime(date, time),
-      location: place || '미정',
+      storeId: selectedStore?.id,
     };
 
     try {
@@ -100,6 +121,25 @@ const ShareWritePage = () => {
     } catch (error) {
       alert('작성 실패' + error);
     }
+  };
+
+  const handleOpenModal = () => {
+    if (!category || !brand) {
+      toast.error(<span>카테고리와 브랜드를 먼저 선택해주세요.</span>, {
+        duration: 2000,
+        style: {
+          border: '1px solid #ebebeb',
+          padding: '16px',
+          color: '#e94e4e',
+        },
+        iconTheme: {
+          primary: '#e94e4e',
+          secondary: '#FFFAEE',
+        },
+      });
+      return;
+    }
+    setShowModal(true);
   };
 
   return (
@@ -129,7 +169,17 @@ const ShareWritePage = () => {
         setSelectedTime={setTime}
       />
 
-      <PlaceField place={place} setPlace={setPlace} />
+      {/* <PlaceField place={place} setPlace={setPlace} /> */}
+      <PlaceField selectedStore={selectedStore} onOpen={handleOpenModal} />
+
+      {showModal && (
+        <SelectStoreModal
+          category={category?.label || null}
+          brand={brand?.label || null}
+          onClose={() => setShowModal(false)}
+          onSelect={(store) => setSelectedStore(store)}
+        />
+      )}
 
       <div className="flex justify-end mt-6">
         <Button onClick={handleSubmit} size="lg">

--- a/src/domains/Explore/types/share.ts
+++ b/src/domains/Explore/types/share.ts
@@ -22,6 +22,7 @@ export interface Post {
   brandImgUrl: string;
   // isClosed: boolean;
   isMine?: boolean;
+  storeName: string;
 }
 
 export interface PostWriteRequest {

--- a/src/domains/Explore/types/share.ts
+++ b/src/domains/Explore/types/share.ts
@@ -31,7 +31,8 @@ export interface PostWriteRequest {
   brandId: string;
   benefitId: string;
   promiseDate: string;
-  location: string;
+  // location: string;
+  storeId: string;
 }
 
 export interface TimeValue {
@@ -43,4 +44,15 @@ export interface TimeValue {
 export interface SelectOption {
   label: string;
   value: string;
+}
+
+export interface Store {
+  id: string;
+  name: string;
+  address: string;
+  category: string;
+  latitude: number;
+  longitude: number;
+  brandName: string;
+  brandImageUrl: string;
 }

--- a/src/domains/Explore/utils/addressUtils.ts
+++ b/src/domains/Explore/utils/addressUtils.ts
@@ -1,0 +1,33 @@
+export const shortenProvince = (address: string): string => {
+  if (!address) return '';
+
+  const parts = address.trim().split(' ');
+
+  if (parts.length < 2) return address;
+
+  const provinceMap: Record<string, string> = {
+    서울특별시: '서울',
+    부산광역시: '부산',
+    대구광역시: '대구',
+    인천광역시: '인천',
+    광주광역시: '광주',
+    대전광역시: '대전',
+    울산광역시: '울산',
+    세종특별자치시: '세종',
+    경기도: '경기',
+    강원특별자치도: '강원',
+    충청북도: '충북',
+    충청남도: '충남',
+    전라북도: '전북',
+    전라남도: '전남',
+    경상북도: '경북',
+    경상남도: '경남',
+    제주특별자치도: '제주',
+    전북특별자치도: '전북',
+  };
+
+  const [province, ...rest] = parts;
+  const shortenedProvince = provinceMap[province] || province;
+
+  return [shortenedProvince, ...rest].join(' ');
+};


### PR DESCRIPTION
## 🔗 관련 이슈

> 이 변경사항과 관련된 이슈 번호를 명시합니다.  
> 예: #123, #456

- #187

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. 채팅 내에서 브랜드 이미지 로드
2. 매장 선택 모달 및 주변 매장 API 연동
3. 대화방 나가기 기능 추가
5. 매장 이름(storeName)과 주소(location) 분리
6. 주소 축약 함수 추가

## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- 브랜드 이미지가 비어 있는 경우 대체 이미지 처리 및 로딩 상태에 따른 UI 개선을 적용했습니다.
- 매장 선택 시 주변 매장을 확인할 수 있도록 API를 연동하였으며, 사용자 위치 기반으로 필터링 기능도 추가했습니다.
- 채팅방 내부에서 ‘나가기’ 버튼을 클릭하면 해당 대화방에서 벗어날 수 있도록 기능을 구현했습니다.
- API 응답에서 매장 이름과 주소를 분리하여 각각 적절한 위치에 표시되도록 구조를 개선했습니다.

## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- 매장 선택 모달에서 주소 축약이 의도대로 보이는지 확인 부탁드립니다.
- 대화방 나가기 후 정상적으로 채팅방 리스트에서 제거되는지 테스트 부탁드립니다.
- 브랜드 이미지 로딩 관련 Fallback 동작도 확인해 주세요.

## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
