### PR TITLE
Feat/detail map

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,8 +21,8 @@ const MENU_CONFIG = {
       { to: '/explore/reward', label: '혜택탐험' },
     ],
     loggedIn: [
-      { to: '/chat', label: '채팅' },
       { to: '/mypage/profile', label: '마이페이지' },
+      { to: '/chat', label: '채팅' },
     ],
   },
   mobile: {
@@ -38,7 +38,6 @@ const MENU_CONFIG = {
       },
     ],
     loggedIn: [
-      { to: '/chat', label: '채팅' },
       {
         label: '마이페이지',
         subItems: [
@@ -50,6 +49,7 @@ const MENU_CONFIG = {
           { to: '/mypage/share', label: '내 나눔' },
         ],
       },
+      { to: '/chat', label: '채팅' },
     ],
     notLoggedIn: [{ to: '/login', label: '로그인' }],
   },

--- a/src/domains/Chat/components/ChatRoomList.tsx
+++ b/src/domains/Chat/components/ChatRoomList.tsx
@@ -50,7 +50,7 @@ const ChatRoomList = ({
                   <div className="flex-1 min-w-0">
                     <div className="flex justify-between items-center mb-1">
                       <h3 className="font-semibold text-sm text-gray-900 truncate">
-                        {room.postResponseDto.author.nickname}
+                        {room.otherNickname}
                       </h3>
                       <span className="text-xs text-gray-400 flex-shrink-0">
                         {timeLabel(room.lastMessageTime || '')}

--- a/src/domains/Chat/components/ChatRoomList.tsx
+++ b/src/domains/Chat/components/ChatRoomList.tsx
@@ -11,27 +11,27 @@ const ChatRoomList = ({
   onRoomSelect: (roomId: string) => void;
 }) => {
   return (
-    <div className="flex-1 md:max-w-sm bg-gray-50 h-full">
+    <div className="overflow-y-auto flex-1 md:max-w-sm md:fixed sm:pt-[86px] bg-gray-100 border-r-1 border-r-gray-200 sm:w-[240px] h-full top-0">
       {/* 헤더 */}
-      <div className="p-4 border-b border-gray-200 bg-white">
+      <div className="p-4 border-b border-gray-200 sm:hidden">
         <h1 className="text-xl font-bold text-gray-900">채팅</h1>
       </div>
 
       {/* 채팅방 목록 */}
-      <div className="overflow-y-auto h-[calc(100%-73px)]">
+      <div>
         {chatRooms.length === 0 ? (
           <div className="p-4">
             <p className="text-gray-500 text-center">채팅방이 없습니다.</p>
           </div>
         ) : (
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-gray-200 p-4 flex flex-col">
             {chatRooms.map((room) => (
               <li
                 key={room.chatRoomId}
                 className={`cursor-pointer rounded ${
                   selectedRoomId === room.chatRoomId
-                    ? 'bg-blue-100'
-                    : 'hover:bg-gray-200'
+                    ? 'bg-[#DDF4FF] border-[#84D8FF] text-[#1CB0F7] hover:bg-[#cee8f5] border-2 rounded-lg'
+                    : 'hover:bg-[#f0f0f0] border-transparent text-gray-500 border-2'
                 }`}
                 onClick={() => onRoomSelect(room.chatRoomId)}
               >
@@ -41,10 +41,10 @@ const ChatRoomList = ({
                     <img
                       src={room.postResponseDto.brandImgUrl}
                       alt="브랜드이미지"
-                      className="w-12 h-12 rounded object-cover"
+                      className="w-12 h-12 rounded  object-contain"
                     />
                   ) : (
-                    <div className="w-12 h-12 rounded object-cover bg-gray-300"></div>
+                    <div className="w-12 h-12 rounded bg-gray-300"></div>
                   )}
                   {/* 채팅방 정보 */}
                   <div className="flex-1 min-w-0">

--- a/src/domains/Chat/pages/ChatContent.tsx
+++ b/src/domains/Chat/pages/ChatContent.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/domains/Explore/utils/datetimeUtils';
 import { leaveChatRoom } from '../api/chat';
 import toast from 'react-hot-toast';
+import { shortenProvince } from '@/domains/Explore/utils/addressUtils';
 
 const ChatContent = ({
   chatRooms,
@@ -29,7 +30,7 @@ const ChatContent = ({
   const navigate = useNavigate();
   const [messageInput, setMessageInput] = useState('');
   const bottomRef = useRef<HTMLDivElement | null>(null);
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const dropdownRef = useRef<HTMLUListElement | null>(null);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const { messages, sendMessage, isLoading } = useWebSocket(
@@ -98,13 +99,13 @@ const ChatContent = ({
     selectedRoom.postResponseDto;
 
   const promiseDateObj = fromISOStringToDateTime(promiseDate);
-
+  console.log(selectedRoom);
   return (
     <main
       className={`flex flex-col h-full ${isMobile ? 'w-full' : 'flex-1'} sm:max-w-[1050px]`}
     >
       {/* 채팅방 헤더 */}
-      <div className="relative border-b border-gray-200 px-4 py-4 shadow-sm flex sm:flex-col items-start gap-3">
+      <div className="relative border-b border-gray-200 px-4 py-4 flex sm:flex-col items-start gap-3">
         {/* 모바일에서만 뒤로가기 버튼 표시 */}
         {isMobile && onBackToList && (
           <button
@@ -134,7 +135,8 @@ const ChatContent = ({
                 {title}
               </h2>
               <p className="flex text-sm text-gray-500 flex-wrap gap-1">
-                <span>{author.nickname}</span>·<span>{location}</span>·
+                <span>{author.nickname}</span>·
+                <span>{shortenProvince(location)}</span>·
                 <span>{`${promiseDateObj.date}, ${promiseDateObj.time.period} ${promiseDateObj.time.hour}:${promiseDateObj.time.minute}`}</span>
               </p>
               <div className="mt-2 sm:mt-0">
@@ -157,7 +159,10 @@ const ChatContent = ({
             <MoreVertical size={20} />
           </button>
           {menuOpen && (
-            <ul className="absolute right-6 top-12 w-40 bg-white border border-gray-200 rounded shadow-lg z-10">
+            <ul
+              ref={dropdownRef}
+              className="absolute right-6 top-12 w-40 bg-white border border-gray-200 rounded shadow-lg z-10"
+            >
               <li
                 onClick={handleLeaveRoom}
                 className="px-4 py-2 text-sm hover:bg-gray-100 cursor-pointer"

--- a/src/domains/Chat/pages/ChatPage.tsx
+++ b/src/domains/Chat/pages/ChatPage.tsx
@@ -169,33 +169,39 @@ const ChatPage = () => {
   }
 
   return (
-    <div className="flex m-6 mt-[62px] sm:mt-[86px] h-[calc(100vh-110px)] w-full max-w-[1340px] mx-auto">
+    <>
       <ChatRoomList
         chatRooms={chatRooms}
         selectedRoomId={selectedRoomId}
         onRoomSelect={handleRoomSelect}
       />
-      {chatRooms.length === 0 ? (
-        <div className="flex-1 flex items-center flex-col gap-2 justify-center">
-          <img src={dolphinFind} alt="Dolphin" className="w-32 h-32" />
-          <p className="text-gray-500">혜택 나누기에서 채팅을 시작해 보세요</p>
-          <Button onClick={() => navigate('/explore/share')}>
-            혜택 나누기 페이지로 이동
-          </Button>
+      <div className="md:ml-[240px] flex justify-center">
+        <div className="flex m-6 mt-[62px] sm:mt-[86px] h-[calc(100vh-110px)] w-full max-w-[1340px] justify-center">
+          {chatRooms.length === 0 ? (
+            <div className="flex-1 flex items-center flex-col gap-2 justify-center">
+              <img src={dolphinFind} alt="Dolphin" className="w-32 h-32" />
+              <p className="text-gray-500">
+                혜택 나누기에서 채팅을 시작해 보세요
+              </p>
+              <Button onClick={() => navigate('/explore/share')}>
+                혜택 나누기 페이지로 이동
+              </Button>
+            </div>
+          ) : selectedRoomId ? (
+            <ChatContent
+              chatRooms={chatRooms}
+              selectedRoomId={selectedRoomId}
+              currentUser={currentUser}
+              onLeaveRoom={handleLeaveRoom}
+            />
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <span className="text-gray-500">채팅방을 선택해주세요.</span>
+            </div>
+          )}
         </div>
-      ) : selectedRoomId ? (
-        <ChatContent
-          chatRooms={chatRooms}
-          selectedRoomId={selectedRoomId}
-          currentUser={currentUser}
-          onLeaveRoom={handleLeaveRoom}
-        />
-      ) : (
-        <div className="flex-1 flex items-center justify-center">
-          <span className="text-gray-500">채팅방을 선택해주세요.</span>
-        </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/src/domains/Chat/types/chat.ts
+++ b/src/domains/Chat/types/chat.ts
@@ -7,6 +7,7 @@ export interface ChatRoom {
   lastMessage?: string;
   lastMessageTime?: string;
   postResponseDto: Post;
+  otherNickname: string;
 }
 
 export interface Message {

--- a/src/domains/Explore/components/ranking/RankingPodium.tsx
+++ b/src/domains/Explore/components/ranking/RankingPodium.tsx
@@ -8,7 +8,7 @@ const RankingPodium = ({ podiumRanks }: PodiumProps) => {
   const [first, second, third] = podiumRanks;
 
   return (
-    <div className="w-full pt-8 md:pt-14 md:pb-6 bg-white rounded-lg shadow-inner">
+    <div className="w-full text-gray-800 pt-8 md:pt-14 md:pb-6 bg-white rounded-lg shadow-inner">
       <div
         className="relative w-full max-w-md mx-auto aspect-[472/312] bg-no-repeat bg-contain bg-center"
         style={{ backgroundImage: `url(${podiumImage})` }}

--- a/src/domains/Explore/components/ranking/StoreRankingList.tsx
+++ b/src/domains/Explore/components/ranking/StoreRankingList.tsx
@@ -11,7 +11,7 @@ const rowClass = 'flex w-full px-4 py-4 items-center';
 const cellBaseClass = 'flex items-center justify-center';
 const columnClass = {
   rank: `flex-[1] ${cellBaseClass} text-center font-bold`,
-  store: `flex-[2] font-bold flex gap-x-4 gap-y-1 flex-wrap items-center min-w-0`,
+  store: `flex-[2] font-bold flex gap-x-4 gap-y-1 flex-wrap sm:flex-nowrap items-center min-w-0`,
   category: `flex-[1.5] ${cellBaseClass} text-center `,
   address: `flex-[1.5] ${cellBaseClass} text-center`,
   usage: `flex-[1] ${cellBaseClass} text-center `,

--- a/src/domains/Explore/components/ranking/StoreRankingList.tsx
+++ b/src/domains/Explore/components/ranking/StoreRankingList.tsx
@@ -36,7 +36,7 @@ const StoreRankingList = ({ rankList }: StoreRankingListProps) => {
         {rankList.map((store, index) => (
           <li
             key={store.id}
-            className={`${rowClass} text-sm sm:text-base flex sm:px-4 py-3.5 sm:py-4 justify-around items-center`}
+            className={`${rowClass} text-gray-800 text-sm sm:text-base flex sm:px-4 py-3.5 sm:py-4 justify-around items-center`}
           >
             <div className={columnClass.rank}>
               {index < 3 ? (

--- a/src/domains/Explore/components/ranking/UserRankingList.tsx
+++ b/src/domains/Explore/components/ranking/UserRankingList.tsx
@@ -9,21 +9,71 @@ type RankingListProps = {
   rankList: UserRank[];
 };
 
-const cellBaseClass = 'flex items-center justify-center';
+const cellBase = 'flex items-center justify-center';
 const columnClass = {
-  rank: `w-[15%] ${cellBaseClass} text-center font-bold`,
-  nickname: 'w-[30%] flex flex-wrap gap-x-4 gap-y-1 items-center',
-  completion: `w-[20%] ${cellBaseClass} text-center`,
-  level: `w-[15%] ${cellBaseClass}`,
-  count: `w-[20%] ${cellBaseClass} text-center`,
+  rank: `flex-[1.5] ${cellBase} text-center font-bold`,
+  nickname: 'flex-[3] flex flex-wrap gap-x-4 gap-y-1 items-center',
+  completion: `flex-[2] ${cellBase} text-center`,
+  level: `flex-[1.5] ${cellBase}`,
+  count: `flex-[2] ${cellBase} text-center`,
 };
 
+const tagClass =
+  'shimmer text-[10px] sm:text-base px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap max-w-[6rem] sm:max-w-[11rem] overflow-hidden text-ellipsis';
+
 const medals = [medalGold, medalSilver, medalBronze];
+
+const RankRow = ({
+  user,
+  index,
+  isSticky,
+  isTopSticky,
+  refProp,
+}: {
+  user: UserRank;
+  index: number;
+  isSticky?: boolean;
+  isTopSticky?: boolean;
+  refProp?: React.RefObject<HTMLLIElement | null>;
+}) => {
+  const stickyClass = isSticky
+    ? `sticky ${isTopSticky ? 'top-15' : 'bottom-4'} bg-[#BBE3E6] rounded-2xl z-10`
+    : '';
+  return (
+    <li
+      ref={refProp}
+      className={`text-sm sm:text-base flex sm:px-4 py-3.5 sm:py-4 justify-around items-center text-gray-800 ${stickyClass}`}
+    >
+      <div className={columnClass.rank}>
+        {index < 3 ? (
+          <img src={medals[index]} alt="메달" className="mx-auto" />
+        ) : (
+          <span className="text-xl">{index + 1}</span>
+        )}
+      </div>
+      <div className={columnClass.nickname}>
+        <span className="font-bold truncate overflow-hidden whitespace-nowrap max-w-[6rem] sm:max-w-[8rem]">
+          {user.nickname}
+        </span>
+        {user.title && <span className={tagClass}>{user.title}</span>}
+      </div>
+      <div className={columnClass.completion}>
+        {Number(user.completePercentage).toFixed(2).replace(/\.00$/, '')}%
+      </div>
+      <div className={columnClass.level}>Lv. {user.level}</div>
+      <div className={columnClass.count}>{user.storeUsage}회</div>
+    </li>
+  );
+};
 
 const UserRankingList = ({ rankList }: RankingListProps) => {
   const [myNickname, setMyNickname] = useState<string | null>(null);
   const [isPassedMyRank, setIsPassedMyRank] = useState(true);
+  const [isMyRankVisible, setIsMyRankVisible] = useState(false);
   const myRankRef = useRef<HTMLLIElement>(null);
+
+  const myRank = rankList.find((u) => u.nickname === myNickname);
+  const myIndex = rankList.findIndex((u) => u.nickname === myNickname);
 
   useEffect(() => {
     const token = localStorage.getItem('authToken');
@@ -31,7 +81,7 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
       setMyNickname(null);
       return;
     }
-
+    console.log(token);
     const fetchUser = async () => {
       try {
         const res = await getUserInfo();
@@ -41,35 +91,50 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
         setMyNickname(null);
       }
     };
-
     fetchUser();
   }, []);
 
   useEffect(() => {
-    if (!myRankRef.current) {
-      return;
-    }
+    if (!myRankRef.current) return;
 
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsMyRankVisible(entry.isIntersecting),
+      { threshold: 0.1 },
+    );
+
+    observer.observe(myRankRef.current);
+    return () => observer.disconnect();
+  }, [myNickname]);
+
+  useEffect(() => {
+    if (!myRankRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsMyRankVisible(entry.isIntersecting),
+      { threshold: 0.1 },
+    );
+
+    observer.observe(myRankRef.current);
+    return () => observer.disconnect();
+  }, [myNickname]);
+
+  useEffect(() => {
     const handleScroll = () => {
       if (!myRankRef.current) return;
 
       const rect = myRankRef.current.getBoundingClientRect();
       setIsPassedMyRank(rect.bottom < 100);
     };
+
     window.addEventListener('scroll', handleScroll);
-    // 초기 상태 체크
-    handleScroll();
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
+    handleScroll(); // 초기 상태 체크
+    return () => window.removeEventListener('scroll', handleScroll);
   }, [myNickname]);
-
-  const myRank = rankList.find((user) => user.nickname === myNickname);
 
   return (
     <>
-      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-700 font-bold break-keep whitespace-normal">
+      {/* 헤더 */}
+      <div className="mt-4 bg-[#F9EBCE] flex px-1 sm:px-4 py-2.5 sm:py-6 rounded-3xl justify-around items-center text-gray-600 font-bold break-keep whitespace-normal">
         <div className={columnClass.rank}>순위</div>
         <div className={columnClass.nickname}>닉네임</div>
         <div className={columnClass.completion}>도감 완성률</div>
@@ -77,78 +142,28 @@ const UserRankingList = ({ rankList }: RankingListProps) => {
         <div className={columnClass.count}>혜택 받은 횟수</div>
       </div>
 
+      {/* 위에 고정된 내 순위 */}
       {myRank && isPassedMyRank && (
-        <div className="sticky top-15 bg-[#BBE3E6] rounded-2xl flex sm:px-4 py-3.5 sm:py-4 justify-around items-center z-10">
-          <div className={columnClass.rank}>
-            {rankList.indexOf(myRank) < 3 ? (
-              <img
-                src={medals[rankList.indexOf(myRank)]}
-                alt="메달"
-                className="mx-auto"
-              />
-            ) : (
-              <span className="text-xl">{rankList.indexOf(myRank) + 1}</span>
-            )}
-          </div>
-          <div className={columnClass.nickname}>
-            <span className="font-bold truncate overflow-hidden whitespace-nowrap">
-              {myRank.nickname}
-            </span>
-            {myRank.title && (
-              <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
-                {myRank.title}
-              </span>
-            )}
-          </div>
-          <div className={columnClass.completion}>
-            {Number(myRank.completePercentage).toFixed(2).replace(/\.00$/, '')}%
-          </div>
-          <div className={columnClass.level}>Lv. {myRank.level}</div>
-          <div className={columnClass.count}>{myRank.storeUsage}회</div>
-        </div>
+        <RankRow user={myRank} index={myIndex} isSticky isTopSticky />
       )}
 
-      <ul>
+      {/* 전체 랭킹 */}
+      <ul className="mt-2 sm:mt-4 bg-white">
         {rankList.map((user, index) => (
-          <li
+          <RankRow
             key={index}
-            ref={user.nickname === myNickname ? myRankRef : null}
-            className={`flex sm:px-4 py-3.5 sm:py-4 justify-around items-center ${
-              user.nickname === myNickname && !isPassedMyRank
-                ? 'sticky bottom-4 bg-[#BBE3E6] rounded-2xl'
-                : ''
-            }`}
-          >
-            <div className={columnClass.rank}>
-              {index < 3 ? (
-                <img src={medals[index]} alt="메달" className="mx-auto" />
-              ) : (
-                <span className="text-xl">{index + 1}</span>
-              )}
-            </div>
-            <div className={columnClass.nickname}>
-              <span className="font-bold truncate overflow-hidden whitespace-nowrap">
-                {user.nickname}
-              </span>
-              {user.title && (
-                <span className="shimmer px-2 py-1.5 rounded-xl w-fit text-[#282ab3] transition-all duration-300 whitespace-nowrap">
-                  {user.title}
-                </span>
-              )}
-            </div>
-            <div className={columnClass.completion}>
-              <div className={columnClass.completion}>
-                {Number(user.completePercentage)
-                  .toFixed(2)
-                  .replace(/\.00$/, '')}
-                %
-              </div>
-            </div>
-            <div className={columnClass.level}>Lv. {user.level}</div>
-            <div className={columnClass.count}>{user.storeUsage}회</div>
-          </li>
+            user={user}
+            index={index}
+            refProp={user.nickname === myNickname ? myRankRef : undefined}
+            isSticky={user.nickname === myNickname && !isPassedMyRank}
+          />
         ))}
       </ul>
+
+      {/* 아래 고정된 내 순위 */}
+      {myRank && !isMyRankVisible && !isPassedMyRank && (
+        <RankRow user={myRank} index={myIndex} isSticky />
+      )}
     </>
   );
 };

--- a/src/domains/Explore/components/ranking/UserTotalRanking.tsx
+++ b/src/domains/Explore/components/ranking/UserTotalRanking.tsx
@@ -3,31 +3,47 @@ import UserRankingList from '@/domains/Explore/components/ranking/UserRankingLis
 import RankingPodium from '@/domains/Explore/components/ranking/RankingPodium';
 import { getUserRank } from '@/domains/Explore/api/rank';
 import type { UserRank } from '@/domains/Explore/types/rank';
+import { Grid } from 'ldrs/react';
+import 'ldrs/react/Grid.css';
 
 const UserTotalRanking = () => {
   const [rankList, setRankList] = useState<UserRank[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchUserRank = async () => {
-      const userRank = await getUserRank();
-      setRankList(userRank);
+      try {
+        const userRank = await getUserRank();
+        setRankList(userRank);
+      } catch (e) {
+        console.error('전체 순위 불러오기 실패', e);
+      } finally {
+        setIsLoading(false);
+      }
     };
     fetchUserRank();
   }, []);
 
-  if (!rankList || rankList.length === 0) {
+  if (isLoading) {
     return (
-      <div className="text-center text-gray-400">
-        아직 랭킹 정보가 없습니다 💤
+      <div className="w-full h-100 flex flex-col justify-center items-center gap-4 text-gray-600">
+        <Grid size="100" speed="1.5" color="#6fc3d1" />
+        순위 데이터를 불러오고 있어요
       </div>
     );
   }
 
+  if (!rankList || rankList.length === 0) {
+    return (
+      <div className="text-center text-gray-400">
+        아직 순위 정보가 없습니다 💤
+      </div>
+    );
+  }
   const podiumRanks = rankList
     .filter((_, i) => i + 1 >= 1 && i + 1 <= 3)
     .sort((a, b) => a.rank - b.rank)
     .map((user) => user.nickname);
-
   return (
     <>
       <RankingPodium podiumRanks={podiumRanks} />
@@ -35,5 +51,4 @@ const UserTotalRanking = () => {
     </>
   );
 };
-
 export default UserTotalRanking;

--- a/src/domains/Explore/components/share/SharePostItem.tsx
+++ b/src/domains/Explore/components/share/SharePostItem.tsx
@@ -78,7 +78,9 @@ const SharePostItem = ({ post }: SharePostItemProps) => {
             <h3 className="text-lg font-bold break-words  pr-10 min-w-0">
               {post.title}
             </h3>
-            <p className="text-gray-600 text-sm line-clamp-1">{post.content}</p>
+            <p className="text-gray-600 text-sm line-clamp-1 max-w-90">
+              {post.content}
+            </p>
             <div className="text-sm flex flex-wrap gap-1 text-gray-300">
               {post.category} · {post.brandName} · {post.benefitName}
             </div>

--- a/src/domains/Explore/pages/ShareDetailPage.tsx
+++ b/src/domains/Explore/pages/ShareDetailPage.tsx
@@ -10,7 +10,9 @@ import { deleteMySharePost } from '@/domains/MyPage/api/myShare';
 import dolphinImg from '@/assets/image/dolphin_normal.png';
 import { getUserInfo } from '@/domains/MyPage/api/profile';
 import { Ring } from 'ldrs/react';
+import { Map, CustomOverlayMap, useKakaoLoader } from 'react-kakao-maps-sdk';
 import 'ldrs/react/Ring.css';
+import CustomMarker from '@/domains/Map/components/CustomMarker';
 
 const ShareDetailPage = () => {
   const { postId = '' } = useParams();
@@ -20,6 +22,8 @@ const ShareDetailPage = () => {
   const [isConfirmLoading, setIsConfirmLoading] = useState(false);
 
   const navigate = useNavigate();
+
+  useKakaoLoader({ appkey: import.meta.env.VITE_KAKAO_API });
 
   useEffect(() => {
     const fetchPost = async () => {
@@ -50,7 +54,6 @@ const ShareDetailPage = () => {
 
   if (isLoading) return <div className="m-6">로딩 중...</div>;
   if (!post) return null;
-
   const dateTime = fromISOStringToDateTime(post.promiseDate);
 
   const handleStartChat = async () => {
@@ -84,8 +87,8 @@ const ShareDetailPage = () => {
   };
 
   return (
-    <>
-      <div className="w-full max-w-[1050px] m-6 flex flex-col gap-5">
+    <div className="w-[calc(100%-48px)] md:w-[80%] max-w-[1050px] mb-50 md:mb-100">
+      <div className="flex flex-col gap-5">
         <div className="flex gap-4 sm:items-center">
           <div className="relative w-16 h-16 sm:w-32 sm:h-32 flex items-center justify-center flex-shrink-0">
             {post.brandImgUrl ? (
@@ -122,8 +125,40 @@ const ShareDetailPage = () => {
             </div>
           </div>
         </div>
-        <p className="text-gray-600">{post.content}</p>
 
+        <p className="text-gray-600">{post.content}</p>
+        {post.storeLatitude && post.storeLongitude && (
+          <div className="mt-6 rounded-xl overflow-hidden w-full h-52">
+            <Map
+              center={{ lat: post.storeLatitude, lng: post.storeLongitude }}
+              style={{ width: '100%', height: '100%' }}
+              level={3}
+              draggable={false}
+              zoomable={false}
+            >
+              {/* 마커 */}
+              <CustomMarker
+                id={post.postId}
+                lat={post.storeLatitude}
+                lng={post.storeLongitude}
+                name={post.storeName}
+                imageUrl={post.brandImgUrl}
+                selected={true} // 상세페이지니까 항상 true로 강조
+                isRecommended={undefined}
+                onClick={() => {}}
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+                shouldCluster={false}
+              />
+
+              {/* 커스텀 오버레이 */}
+              <CustomOverlayMap
+                position={{ lat: post.storeLatitude, lng: post.storeLongitude }}
+                yAnchor={1}
+              ></CustomOverlayMap>
+            </Map>
+          </div>
+        )}
         <div className="flex justify-end">
           {post.isMine ? (
             <>
@@ -188,7 +223,7 @@ const ShareDetailPage = () => {
           </>
         }
       ></Modal>
-    </>
+    </div>
   );
 };
 

--- a/src/domains/Explore/pages/SharePage.tsx
+++ b/src/domains/Explore/pages/SharePage.tsx
@@ -129,19 +129,13 @@ const SharePage = () => {
   useEffect(() => {
     if (!location) return;
 
-    // 위치가 변경될 때만 포스트 리스트 초기화 후 로드
-    const shouldResetPosts =
-      postList.length === 0 ||
-      postList.some((post) => post.location !== location.value);
-
-    if (shouldResetPosts) {
-      setPostList([]);
-      setPage(0);
-      setHasNextPage(true);
-      setIsLoading(true);
-      fetchPostList(0, location.value);
-    }
-  }, [location, postList]);
+    // 최초 또는 location 변경 시 초기 fetch
+    setPostList([]);
+    setPage(0);
+    setHasNextPage(true);
+    setIsLoading(true);
+    fetchPostList(0, location.value);
+  }, [location]);
 
   useEffect(() => {
     if (!location) return;

--- a/src/domains/Explore/types/share.ts
+++ b/src/domains/Explore/types/share.ts
@@ -23,6 +23,8 @@ export interface Post {
   // isClosed: boolean;
   isMine?: boolean;
   storeName: string;
+  storeLatitude: number;
+  storeLongitude: number;
 }
 
 export interface PostWriteRequest {


### PR DESCRIPTION
## 🔗 관련 이슈

> 이 변경사항과 관련된 이슈 번호를 명시합니다.  
> 예: #123, #456

- #213 

## 📝 변경 사항

> 커밋 단위로 명시적으로 짧게 작성합니다.

1. ShareDetailPage에 카카오맵 추가
2. 필터 상태를 URL에 반영
3. 게시글 목록의 본문 길이 조정
4. 랭킹 로딩 복원
5. 채팅방 UI 스타일 수정
7. 채팅방 목록에 사용자 이름 표시 방식 개선
8. 헤더 컴포넌트 내부 순서 정리
9. 매장 순위 카드 스타일 개선


## 🔍 변경 사항 세부 설명

> 세부 설명을 작성합니다.

- ShareDetailPage 내에 카카오 맵 컴포넌트를 추가하여 위치 정보 제공
- SharePage 필터 상태(location, category 등)를 URL 쿼리로 저장/복원 가능하도록 개선
- 게시글 카드 본문 영역 길이를 줄여 리스트에서 가독성 개선
- SharePage의 location 변경 시 발생하던 무한 호출 문제 수정
- 채팅방 목록에서 사용자 이름 포맷 변경
- 헤더 컴포넌트 순서를 조정하여 구조 정리


## 🕵️‍♀️ 요청사항

> 팀원들에게 테스트나 리뷰를 요청합니다.

- SharePage와 채팅 UI 변경 사항 테스트 부탁드립니다
- ShareDetailPage의 카카오맵 정상 표시 여부 확인 부탁드립니다


## 📷 스크린샷 (선택)

> UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨
